### PR TITLE
build(AUR): :construction_worker: Added aur configuration for talhelper

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,13 +13,32 @@ builds:
 archives:
   - name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs'
-      - '^test'
-      - '^chore'
+      - "^docs"
+      - "^test"
+      - "^chore"
+
+aurs:
+  - name: talhelper-bin
+    homepage: "https://github.com/budimanjojo/talhelper"
+    description: "A tool to help creating Talos cluster in GitOps way."
+    maintainers:
+      - Budiman Jojo <budimanjojo at gmail dot com>
+    license: "BSD-3-Clause"
+    skip_upload: "auto"
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/talhelper-bin.git"
+    package: |-
+      # bin
+      install -Dm755 "./{{ .ProjectName }}" "${pkgdir}/usr/bin/{{ .ProjectName }}"
+      # license
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/{{ .ProjectName }}/LICENSE"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com


### PR DESCRIPTION
Adds aur configuration to goreleaser. This makes is very easy for AUR users to install talhelper using their native package manager.

While the configuration works, the following steps must be taken:

- [x] Create an account with the AUR if you do not have one
- [x] Add an ssh key to it for identity
- [x] Create the AUR repository aur@aur.archlinux.org/talhelper-bin.git (simply clone 'ssh://aur@aur.archlinux.org/talhelper-bin.git' with your key to create a blank repository)
- [x] Add the key to the github actions via the environment variable AUR_KEY


Happy to help out if you haven't used the aur before.