### PR TITLE
Add windows-amd64 build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,15 @@ builds:
       - arm64
     ldflags:
       - -s -w -X github.com/budimanjojo/talhelper/cmd.version={{.Version}}
+  - id: talhelper-windows-amd64
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X github.com/budimanjojo/talhelper/cmd.version={{.Version}}
 archives:
   - name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
 checksum:


### PR DESCRIPTION
Adding a windows build to each release seems quite easy and itwould make working with our talos clusters from a Windows machine a bit easier. I tested it on my machine and seems to work great! 