### PR TITLE
Add embedded Scoop manifest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,3 +51,17 @@ aurs:
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
+
+scoop:
+  url_template: 'https://github.com/budimanjojo/talhelper/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+  bucket:
+    owner: budimanjojo
+    name: talhelper
+    branch: master
+    pull_request:
+      enabled: false
+  commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+  homepage: "https://github.com/budimanjojo/talhelper"
+  description: "A tool to help creating Talos kubernetes cluster"
+  license: BSD-3
+  depends: ["sops"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ There are several ways to install `talhelper`:
   ```
   curl https://i.jpillora.com/budimanjojo/talhelper! | sudo bash
   ```
+- On Windows, using [scoop](https://scoop.sh/):
+  ```
+  scoop bucket add budimanjojo https://github.com/budimanjojo/talhelper.git
+  scoop install talhelper
+  ```  
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ## Usage


### PR DESCRIPTION
This PR uses a [Gorelease feature](https://goreleaser.com/customization/scoop/?h=scoop) to create a scoop manifest after release. Once merged and after the first release, one can install talhelper by running

```
scoop bucket add budimanjojo https://github.com/budimanjojo/talhelper.git
scoop install talhelper
```

As soon as the first Windows release is available as an asset, we can also try to get it added to the [Main scoop bucket](https://github.com/ScoopInstaller/Main/). But as it does not matches the [criteria](https://github.com/ScoopInstaller/Scoop/wiki/Criteria-for-including-apps-in-the-main-bucket) yet, we'll probably need to add it to the [Extras](https://github.com/ScoopInstaller/Extras) bucket where there's a big backlog of PRs and the steps to install it are not much different than just using the manifest inside the talhelper repo.