### PR TITLE
feat(config): add controlplane and worker schematic

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -611,6 +611,25 @@ inlinePatch:
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
+<tr markdown="1">
+<td markdown="1">`schematic`</td>
+<td markdown="1">[Schematic](#schematic)</td>
+<td markdown="1">Configure Talos image customization to be applied to all controlplane nodes<details><summary>*Show example*</summary>
+```yaml
+schematic:
+  customization:
+    extraKernelArgs:
+      - net.ifnames=0
+    systemExtensions:
+      officialExtensions:
+        officialExtensions:
+          - siderolabs/intel-ucode
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
 </table>
 
 ## Worker
@@ -674,6 +693,25 @@ inlinePatch:
 ```
 </summary></td>
 <td markdown="1" align="center">`map[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`schematic`</td>
+<td markdown="1">[Schematic](#schematic)</td>
+<td markdown="1">Configure Talos image customization to be applied to all worker nodes<details><summary>*Show example*</summary>
+```yaml
+schematic:
+  customization:
+    extraKernelArgs:
+      - net.ifnames=0
+    systemExtensions:
+      officialExtensions:
+        officialExtensions:
+          - siderolabs/intel-ucode
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -122,3 +122,8 @@ worker:
         value:
           feature-gates: GracefulNodeShutdown=false,MixedProtocolLBService=false
           rotate-server-certificates: "true"
+  schematic:
+    customization:
+      systemExtensions:
+        officialExtensions:
+          - siderolabs/intel-ucode

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,10 +55,12 @@ type controlPlane struct {
 	ConfigPatches []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	InlinePatch   map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	Patches       []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all controlplane nodes"`
+	Schematic     *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all controlplane nodes"`
 }
 
 type worker struct {
 	ConfigPatches []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	InlinePatch   map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	Patches       []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all worker nodes"`
+	Schematic     *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all worker nodes"`
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -32,6 +32,19 @@ func LoadAndValidateFromFile(filePath string, envPaths []string) (*TalhelperConf
 		return nil, fmt.Errorf("failed to unmarshal config file: %s", err)
 	}
 
+	for k, node := range cfg.Nodes {
+		switch node.ControlPlane {
+		case true:
+			if cfg.ControlPlane.Schematic != nil && node.Schematic == nil {
+				cfg.Nodes[k].Schematic = cfg.ControlPlane.Schematic
+			}
+		case false:
+			if cfg.Worker.Schematic != nil && node.Schematic == nil {
+				cfg.Nodes[k].Schematic = cfg.Worker.Schematic
+			}
+		}
+	}
+
 	errs, warns := cfg.Validate()
 	if len(errs) > 0 || len(warns) > 0 {
 		color.Red("There are issues with your talhelper config file:")

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+func TestLoadAndValidateFromFile(t *testing.T) {
+	cfg, err := LoadAndValidateFromFile("testdata/talconfig.yaml", []string{"testdata/env1.yaml", "testdata/env2.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedClusterName := "test-cluster"
+	expectedNode0 := Node{
+		Hostname:     "hostname1",
+		IPAddress:    "192.168.200.10",
+		ControlPlane: true,
+		InstallDisk:  "/dev/sda",
+		Schematic: &schematic.Schematic{
+			Customization: schematic.Customization{
+				SystemExtensions: schematic.SystemExtensions{
+					OfficialExtensions: []string{"siderolabs/tailscale"},
+				},
+			},
+		},
+	}
+	expectedNode1 := Node{
+		Hostname:     "hostname2",
+		IPAddress:    "192.168.200.11",
+		ControlPlane: false,
+		InstallDisk:  "/dev/sda",
+		Schematic: &schematic.Schematic{
+			Customization: schematic.Customization{
+				ExtraKernelArgs: []string{"net.ifnames=0"},
+			},
+		},
+	}
+
+	if cfg.ClusterName != expectedClusterName {
+		t.Errorf("got %s, want %s", cfg.ClusterName, expectedClusterName)
+	}
+
+	if !reflect.DeepEqual(cfg.Nodes[0], expectedNode0) {
+		t.Errorf("got:\n%v\nwant:\n%v", cfg.Nodes[0], expectedNode0)
+	}
+
+	if !reflect.DeepEqual(cfg.Nodes[1], expectedNode1) {
+		t.Errorf("got:\n%v\nwant:\n%v", cfg.Nodes[1], expectedNode1)
+	}
+}

--- a/pkg/config/testdata/env1.yaml
+++ b/pkg/config/testdata/env1.yaml
@@ -1,0 +1,2 @@
+HOSTNAME1: hostname1
+IP1: 192.168.200.10

--- a/pkg/config/testdata/env2.yml
+++ b/pkg/config/testdata/env2.yml
@@ -1,0 +1,1 @@
+HOSTNAME2: hostname2

--- a/pkg/config/testdata/talconfig.yaml
+++ b/pkg/config/testdata/talconfig.yaml
@@ -1,0 +1,28 @@
+---
+clusterName: test-cluster
+endpoint: https://192.168.200.10:6443
+nodes:
+  - hostname: ${HOSTNAME1}
+    ipAddress: ${IP1}
+    installDisk: /dev/sda
+    controlPlane: true
+    schematic:
+      customization:
+        systemExtensions:
+          officialExtensions:
+            - siderolabs/tailscale
+  - hostname: ${HOSTNAME2}
+    ipAddress: "192.168.200.11"
+    installDisk: /dev/sda
+    controlPlane: false
+controlPlane:
+  schematic:
+    customization:
+      systemExtensions:
+        officialExtensions:
+          - siderolabs/intel-ucode
+worker:
+  schematic:
+    customization:
+      extraKernelArgs:
+        - net.ifnames=0


### PR DESCRIPTION
The schematic can be applied to all nodes based on their types. But it will prioritize `node[].schematic` if specified.

Fixes: https://github.com/budimanjojo/talhelper/issues/217