### PR TITLE
feat(gencommand): add bootstrap subcommand

### DIFF
--- a/cmd/gencommand_bootstrap.go
+++ b/cmd/gencommand_bootstrap.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/pkg/generate"
+)
+
+var (
+	gencommandBootstrapOutDir  string
+	gencommandBootstrapCfgFile string
+	gencommandBootstrapEnvFile []string
+
+	gencommandBootstrapFlagNode   string
+	gencommandBootstrapExtraFlags []string
+)
+
+var gencommandBootstrapCmd = &cobra.Command{
+	Use:   "bootstrap",
+	Short: "Generate talosctl bootstrap commands.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := config.LoadAndValidateFromFile(gencommandBootstrapCfgFile, gencommandBootstrapEnvFile)
+		if err != nil {
+			log.Fatalf("failed to parse config file: %s", err)
+		}
+
+		err = generate.GenerateBootstrapCommand(cfg, gencommandBootstrapOutDir, gencommandBootstrapFlagNode, gencommandBootstrapExtraFlags)
+		if err != nil {
+			log.Fatalf("failed to generate talosctl bootstrap command: %s", err)
+		}
+	},
+}
+
+func init() {
+	gencommandCmd.AddCommand(gencommandBootstrapCmd)
+	gencommandBootstrapCmd.Flags().StringVarP(&gencommandBootstrapCfgFile, "config-file", "c", "talconfig.yaml", "File containing configurations for talhelper")
+	gencommandBootstrapCmd.Flags().StringVarP(&gencommandBootstrapOutDir, "out-dir", "o", "./clusterconfig", "Directory where the generated files were dumped with `genconfig`.")
+	gencommandBootstrapCmd.Flags().StringSliceVar(&gencommandBootstrapEnvFile, "env-file", []string{"talenv.yaml", "talenv.sops.yaml", "talenv.yml", "talenv.sops.yml"}, "List of files containing env variables for config file")
+	gencommandBootstrapCmd.Flags().StringSliceVar(&gencommandBootstrapExtraFlags, "extra-flags", []string{}, "List of additional flags that will be injected into the generated commands.")
+	gencommandBootstrapCmd.Flags().StringVarP(&gencommandBootstrapFlagNode, "node", "n", "", "A specific node to generate the command for. If not specified, will generate for all nodes.")
+}

--- a/pkg/generate/command.go
+++ b/pkg/generate/command.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"fmt"
 	"strings"
+
 	"github.com/budimanjojo/talhelper/pkg/config"
 	"github.com/budimanjojo/talhelper/pkg/talos"
 	"github.com/siderolabs/image-factory/pkg/schematic"
@@ -10,7 +11,7 @@ import (
 
 func GenerateApplyCommand(cfg *config.TalhelperConfig, gencommandOutDir string, gencommandFlagNode string, gencommandExtraFlags []string) error {
 	for _, node := range cfg.Nodes {
-		isSelectedNode := ( (gencommandFlagNode != "") && (gencommandFlagNode == node.IPAddress) )
+		isSelectedNode := ((gencommandFlagNode != "") && (gencommandFlagNode == node.IPAddress))
 		allNodesSelected := (gencommandFlagNode == "")
 
 		if allNodesSelected || isSelectedNode {
@@ -29,7 +30,7 @@ func GenerateApplyCommand(cfg *config.TalhelperConfig, gencommandOutDir string, 
 
 func GenerateUpgradeCommand(cfg *config.TalhelperConfig, gencommandOutDir string, gencommandFlagNode string, gencommandInstallerRegistryURL string, gencommandExtraFlags []string) error {
 	for _, node := range cfg.Nodes {
-		isSelectedNode := ( (gencommandFlagNode != "") && (gencommandFlagNode == node.IPAddress) )
+		isSelectedNode := ((gencommandFlagNode != "") && (gencommandFlagNode == node.IPAddress))
 		allNodesSelected := (gencommandFlagNode == "")
 
 		if allNodesSelected || isSelectedNode {
@@ -51,6 +52,33 @@ func GenerateUpgradeCommand(cfg *config.TalhelperConfig, gencommandOutDir string
 			}
 			upgradeFlags = append(upgradeFlags, gencommandExtraFlags...)
 			fmt.Printf("talosctl upgrade %s;\n", strings.Join(upgradeFlags, " "))
+		}
+	}
+
+	return nil
+}
+
+func GenerateBootstrapCommand(cfg *config.TalhelperConfig, gencommandOutDir string, gencommandFlagNode string, gencommandExtraFlags []string) error {
+	for _, node := range cfg.Nodes {
+		isSelectedNode := ((gencommandFlagNode != "") && (gencommandFlagNode == node.IPAddress))
+		noNodeSelected := (gencommandFlagNode == "")
+		bootstrapFlags := []string{
+			"--talosconfig=" + gencommandOutDir + "/talosconfig",
+		}
+		if noNodeSelected && node.ControlPlane {
+			bootstrapFlags = append(bootstrapFlags, gencommandExtraFlags...)
+			bootstrapFlags = append(bootstrapFlags, "--nodes="+node.IPAddress)
+			fmt.Printf("talosctl bootstrap %s;\n", strings.Join(bootstrapFlags, " "))
+			break
+		}
+		if isSelectedNode {
+			if !node.ControlPlane {
+				return fmt.Errorf("%s is not a controlplane node", node.IPAddress)
+			}
+			bootstrapFlags = append(bootstrapFlags, gencommandExtraFlags...)
+			bootstrapFlags = append(bootstrapFlags, "--nodes="+node.IPAddress)
+			fmt.Printf("talosctl bootstrap %s;\n", strings.Join(bootstrapFlags, " "))
+			break
 		}
 	}
 


### PR DESCRIPTION
If no `--node` flag is provided, will use the first controlplane node. If the provided flag is not a controlplane node, will return error and exit 1

Fixes: https://github.com/budimanjojo/talhelper/issues/223