### PR TITLE
feat: use HTTP POST request to generate schematic id

### DIFF
--- a/cmd/gencommand_upgrade.go
+++ b/cmd/gencommand_upgrade.go
@@ -9,8 +9,6 @@ import (
 	"github.com/budimanjojo/talhelper/pkg/generate"
 )
 
-var gencommandUpgradeInstallerRegistryURL string
-
 var gencommandUpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Generate talosctl upgrade commands.",
@@ -21,7 +19,7 @@ var gencommandUpgradeCmd = &cobra.Command{
 			log.Fatalf("failed to parse config file: %s", err)
 		}
 
-		err = generate.GenerateUpgradeCommand(cfg, gencommandOutDir, gencommandNode, gencommandUpgradeInstallerRegistryURL, gencommandExtraFlags)
+		err = generate.GenerateUpgradeCommand(cfg, gencommandOutDir, gencommandNode, gencommandExtraFlags)
 		if err != nil {
 			log.Fatalf("failed to generate talosctl upgrade command: %s", err)
 		}
@@ -30,5 +28,4 @@ var gencommandUpgradeCmd = &cobra.Command{
 
 func init() {
 	gencommandCmd.AddCommand(gencommandUpgradeCmd)
-	gencommandUpgradeCmd.Flags().StringVarP(&gencommandUpgradeInstallerRegistryURL, "registry-url", "r", "factory.talos.dev/installer", "Registry url of the image")
 }

--- a/cmd/genconfig.go
+++ b/cmd/genconfig.go
@@ -19,6 +19,7 @@ var (
 	genconfigEnvFile     []string
 	genconfigSecretFile  []string
 	genconfigDryRun      bool
+	genconfigOfflineMode bool
 )
 
 var genconfigCmd = &cobra.Command{
@@ -42,7 +43,7 @@ var genconfigCmd = &cobra.Command{
 			}
 		}
 
-		err = generate.GenerateConfig(cfg, genconfigDryRun, genconfigOutDir, secretFile, genconfigTalosMode)
+		err = generate.GenerateConfig(cfg, genconfigDryRun, genconfigOutDir, secretFile, genconfigTalosMode, genconfigOfflineMode)
 		if err != nil {
 			log.Fatalf("failed to generate talos config: %s", err)
 		}
@@ -66,4 +67,5 @@ func init() {
 	genconfigCmd.Flags().StringVarP(&genconfigTalosMode, "talos-mode", "m", "metal", "Talos runtime mode to validate generated config")
 	genconfigCmd.Flags().BoolVar(&genconfigNoGitignore, "no-gitignore", false, "Create/update gitignore file too")
 	genconfigCmd.Flags().BoolVarP(&genconfigDryRun, "dry-run", "n", false, "Skip generating manifests and show diff instead")
+	genconfigCmd.Flags().BoolVar(&genconfigOfflineMode, "offline-mode", false, "Generate schematic ID without doing POST request to image-factory")
 }

--- a/cmd/genurl_installer.go
+++ b/cmd/genurl_installer.go
@@ -21,6 +21,7 @@ var (
 	genurlInstallerVersion     string
 	genurlInstallerExtensions  []string
 	genurlInstallerKernelArgs  []string
+	genurlInstallerOfflineMode bool
 )
 
 var genurlInstallerCmd = &cobra.Command{
@@ -45,7 +46,7 @@ var genurlInstallerCmd = &cobra.Command{
 				}
 
 				if node.IPAddress == genurlInstallerNode {
-					url, err := talos.GetInstallerURL(schema, genurlInstallerRegistryURL, cfg.GetTalosVersion())
+					url, err := talos.GetInstallerURL(schema, cfg.GetImageFactory(), cfg.GetTalosVersion(), genurlInstallerOfflineMode)
 					if err != nil {
 						log.Fatalf("Failed to generate installer url for %s, %v", node.Hostname, err)
 					}
@@ -53,7 +54,7 @@ var genurlInstallerCmd = &cobra.Command{
 					break
 				}
 
-				url, err := talos.GetInstallerURL(schema, genurlInstallerRegistryURL, cfg.GetTalosVersion())
+				url, err := talos.GetInstallerURL(schema, cfg.GetImageFactory(), cfg.GetTalosVersion(), genurlInstallerOfflineMode)
 				if err != nil {
 					log.Fatalf("Failed to generate installer url for %s, %v", node.Hostname, err)
 				}
@@ -80,8 +81,10 @@ var genurlInstallerCmd = &cobra.Command{
 					},
 				},
 			}
+			tconfig := &config.TalhelperConfig{}
+			tconfig.ImageFactory.RegistryURL = genurlInstallerRegistryURL
 
-			url, err := talos.GetInstallerURL(cfg, genurlInstallerRegistryURL, genurlInstallerVersion)
+			url, err := talos.GetInstallerURL(cfg, tconfig.GetImageFactory(), genurlInstallerVersion, genurlInstallerOfflineMode)
 			if err != nil {
 				log.Fatalf("Failed to generate installer url, %v", err)
 			}
@@ -99,8 +102,9 @@ func init() {
 	genurlInstallerCmd.Flags().StringVarP(&genurlInstallerCfgFile, "config-file", "c", "talconfig.yaml", "File containing configurations for talhelper")
 	genurlInstallerCmd.Flags().StringSliceVar(&genurlInstallerEnvFile, "env-file", []string{"talenv.yaml", "talenv.sops.yaml", "talenv.yml", "talenv.sops.yml"}, "List of files containing env variables for config file")
 	genurlInstallerCmd.Flags().StringVarP(&genurlInstallerNode, "node", "n", "", "A specific node to generate command for. If not specified, will generate for all nodes (ignored when talconfig.yaml is not found)")
-	genurlInstallerCmd.Flags().StringVarP(&genurlInstallerRegistryURL, "registry-url", "r", "factory.talos.dev/installer", "Registry url of the image")
+	genurlInstallerCmd.Flags().StringVarP(&genurlInstallerRegistryURL, "registry-url", "r", "factory.talos.dev", "Registry url of the image")
 	genurlInstallerCmd.Flags().StringVarP(&genurlInstallerVersion, "version", "v", config.LatestTalosVersion, "Talos version to generate (defaults to latest Talos version)")
 	genurlInstallerCmd.Flags().StringSliceVarP(&genurlInstallerExtensions, "extension", "e", []string{}, "Official extension image to be included in the image (ignored when talconfig.yaml is found)")
 	genurlInstallerCmd.Flags().StringSliceVarP(&genurlInstallerKernelArgs, "kernel-arg", "k", []string{}, "Kernel arguments to be passed to the image kernel (ignored when talconfig.yaml is found)")
+	genurlInstallerCmd.Flags().BoolVar(&genurlInstallerOfflineMode, "offline-mode", false, "Generate schematic ID without doing POST request to image-factory")
 }

--- a/cmd/genurl_iso.go
+++ b/cmd/genurl_iso.go
@@ -23,6 +23,7 @@ var (
 	genurlISOArch        string
 	genurlISOExtensions  []string
 	genurlISOKernelArgs  []string
+	genurlISOOfflineMode bool
 )
 
 var genurlISOCmd = &cobra.Command{
@@ -47,7 +48,7 @@ var genurlISOCmd = &cobra.Command{
 				}
 
 				if node.IPAddress == genurlISONode {
-					url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch)
+					url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
 					if err != nil {
 						log.Fatalf("Failed to generate ISO url for %s, %v", node.Hostname, err)
 					}
@@ -55,7 +56,7 @@ var genurlISOCmd = &cobra.Command{
 					break
 				}
 
-				url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch)
+				url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
 				if err != nil {
 					log.Fatalf("Failed to generate ISO url for %s, %v", node.Hostname, err)
 				}
@@ -82,7 +83,7 @@ var genurlISOCmd = &cobra.Command{
 					},
 				},
 			}
-			url, err := talos.GetISOURL(cfg, genurlISORegistryURL, genurlISOVersion, genurlISOTalosMode, genurlISOArch)
+			url, err := talos.GetISOURL(cfg, genurlISORegistryURL, genurlISOVersion, genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
 			if err != nil {
 				log.Fatalf("Failed to generate installer url, %v", err)
 			}
@@ -100,10 +101,11 @@ func init() {
 	genurlISOCmd.Flags().StringVarP(&genurlISOCfgFile, "config-file", "c", "talconfig.yaml", "File containing configurations for talhelper")
 	genurlISOCmd.Flags().StringSliceVar(&genurlISOEnvFile, "env-file", []string{"talenv.yaml", "talenv.sops.yaml", "talenv.yml", "talenv.sops.yml"}, "List of files containing env variables for config file")
 	genurlISOCmd.Flags().StringVarP(&genurlISONode, "node", "n", "", "A specific node to generate command for. If not specified, will generate for all nodes (ignored when talconfig.yaml is not found)")
-	genurlISOCmd.Flags().StringVarP(&genurlISORegistryURL, "registry-url", "r", "https://factory.talos.dev/image", "Registry url of the image")
+	genurlISOCmd.Flags().StringVarP(&genurlISORegistryURL, "registry-url", "r", "factory.talos.dev", "Registry url of the image")
 	genurlISOCmd.Flags().StringVarP(&genurlISOVersion, "version", "v", config.LatestTalosVersion, "Talos version to generate (defaults to latest Talos version)")
 	genurlISOCmd.Flags().StringVarP(&genurlISOTalosMode, "talos-mode", "m", "metal", "Talos runtime mode to generate URL")
 	genurlISOCmd.Flags().StringVarP(&genurlISOArch, "arch", "a", "amd64", "CPU architecture support of the image")
 	genurlISOCmd.Flags().StringSliceVarP(&genurlISOExtensions, "extension", "e", []string{}, "Official extension image to be included in the image (ignored when talconfig.yaml is found)")
 	genurlISOCmd.Flags().StringSliceVarP(&genurlISOKernelArgs, "kernel-arg", "k", []string{}, "Kernel arguments to be passed to the image kernel (ignored when talconfig.yaml is found)")
+	genurlISOCmd.Flags().BoolVar(&genurlISOOfflineMode, "offline-mode", false, "Generate schematic ID without doing POST request to image-factory")
 }

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -175,6 +175,22 @@ cniConfig:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`imageFactory`</td>
+<td markdown="1">[ImageFactory](#imagefactory)</td>
+<td markdown="1">Configures selfhosted image factory.<details><summary>*Show example*</summary>
+```yaml
+imageFactory:
+  registryURL: myfactory.com
+  schematicEndpoint: /schematics
+  protocol: https
+  installerURLTmpl: {{.RegistryURL}}/installer/{{.ID}}:{{.Version}}
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`patches`</td>
 <td markdown="1">[]string</td>
 <td markdown="1"><details><summary>Patches to be applied to all nodes.</summary>List of strings containing RFC6902 JSON patches, strategic merge patches,<br />or a file containing them</details><details><summary>*Show example*</summary>
@@ -542,6 +558,65 @@ urls:
 ```
 </summary></td>
 <td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+</table>
+
+## ImageFactory
+
+`ImageFactory` defines configuration for selfhosted image-factory.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`registryURL`</td>
+<td markdown="1">string</td>
+<td markdown="1">Registry URL of the factory.<details><summary>*Show example*</summary>
+```yaml
+registryURL: myfactory.com
+```
+</details></td>
+<td markdown="1" align="center">`"factory.talos.dev"`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`protocol`</td>
+<td markdown="1">string</td>
+<td markdown="1">Protocol the registry is listening to.<details><summary>*Show example*</summary>
+```yaml
+protocol: http
+```
+</summary></td>
+<td markdown="1" align="center">`https`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`schematicEndpoint`</td>
+<td markdown="1">string</td>
+<td markdown="1">Path to do HTTP POST request to the registry.</details><details><summary>*Show example*</summary>
+```yaml
+schematicEndpoint: /schematics
+```
+</summary></td>
+<td markdown="1" align="center">`/schematics`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`installerURLTmpl`</td>
+<td markdown="1">string</td>
+<td markdown="1"><details><summary>Go template to parse the full installer URL.</summary>Available placeholders: `RegistryURL`,`ID`,`Version`</details><details><summary>*Show example*</summary>
+```yaml
+installerURLTmpl: "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}"
+```
+</summary></td>
+<td markdown="1" align="center">`{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type TalhelperConfig struct {
 	CNIConfig                      cniConfig    `yaml:"cniConfig,omitempty" jsonschema:"description=The CNI to be used for the cluster's network"`
 	Patches                        []string     `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all nodes"`
 	Nodes                          []Node       `yaml:"nodes" jsonschema:"required,description=List of configurations for Node"`
+	ImageFactory                   ImageFactory `yaml:"imageFactory,omitempty" jsonschema:"Configuration for image factory"`
 	ControlPlane                   controlPlane `yaml:"controlPlane,omitempty" jsonschema:"description=Configurations targetted for controlplane nodes"`
 	Worker                         worker       `yaml:"worker,omitempty" jsonschema:"description=Configurations targetted for worker nodes"`
 }
@@ -63,4 +64,11 @@ type worker struct {
 	InlinePatch   map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	Patches       []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all worker nodes"`
 	Schematic     *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all worker nodes"`
+}
+
+type ImageFactory struct {
+	RegistryURL       string `yaml:"registryURL,omitempty" jsonschema:"default=factory.talos.dev,description=Registry url or the image"`
+	SchematicEndpoint string `yaml:"schematicEndpoint,omitempty" jsonschema:"default=/schematics,description:Endpoint to get schematic ID from the registry"`
+	Protocol          string `yaml:"protocol,omitempty" jsonschema:"default=https,description=Protocol of the registry(https or http)"`
+	InstallerURLTmpl  string `yaml:"installerURLTmpl,omitempty" jsonschema:"default={{.RegistryURL}}/installer/{{.ID}}:{{.Version}},description=Template for installer image URL"`
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -85,6 +85,29 @@ func (c *TalhelperConfig) GetInstallerURL() string {
 	return "ghcr.io/siderolabs/installer:" + c.GetTalosVersion()
 }
 
+// GetImageFactory returns default `imageFactory` if not specified.
+func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
+	result := ImageFactory{
+		RegistryURL:       "factory.talos.dev",
+		SchematicEndpoint: "/schematics",
+		Protocol:          "https",
+		InstallerURLTmpl:  "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}",
+	}
+	if c.ImageFactory.RegistryURL != "" {
+		result.RegistryURL = c.ImageFactory.RegistryURL
+	}
+	if c.ImageFactory.SchematicEndpoint != "" {
+		result.SchematicEndpoint = c.ImageFactory.SchematicEndpoint
+	}
+	if c.ImageFactory.Protocol != "" {
+		result.Protocol = c.ImageFactory.Protocol
+	}
+	if c.ImageFactory.InstallerURLTmpl != "" {
+		result.InstallerURLTmpl = c.ImageFactory.InstallerURLTmpl
+	}
+	return &result
+}
+
 // endpointisIPv6 returns true if string is IPv6 address.
 func endpointisIPv6(ep string) bool {
 	addr, err := netip.ParseAddr(ep)

--- a/pkg/generate/command.go
+++ b/pkg/generate/command.go
@@ -44,7 +44,7 @@ func GenerateApplyCommand(cfg *config.TalhelperConfig, outDir string, node strin
 // `outDir` is directory where talosconfig is located.
 // If `node` is empty string, it prints commands for all nodes in `cfg.Nodes`.
 // It returns error, if any.
-func GenerateUpgradeCommand(cfg *config.TalhelperConfig, outDir string, node string, installerRegistryURL string, extraFlags []string) error {
+func GenerateUpgradeCommand(cfg *config.TalhelperConfig, outDir string, node string, extraFlags []string) error {
 	var result []string
 	for _, n := range cfg.Nodes {
 		isSelectedNode := ((node != "") && (node == n.IPAddress))
@@ -54,12 +54,12 @@ func GenerateUpgradeCommand(cfg *config.TalhelperConfig, outDir string, node str
 			var url string
 			if n.Schematic != nil {
 				var err error
-				url, err = talos.GetInstallerURL(n.Schematic, installerRegistryURL, cfg.GetTalosVersion())
+				url, err = talos.GetInstallerURL(n.Schematic, cfg.GetImageFactory(), cfg.GetTalosVersion(), true)
 				if err != nil {
 					return fmt.Errorf("Failed to generate installer url for %s, %v", n.Hostname, err)
 				}
 			} else {
-				url, _ = talos.GetInstallerURL(&schematic.Schematic{}, installerRegistryURL, cfg.GetTalosVersion())
+				url, _ = talos.GetInstallerURL(&schematic.Schematic{}, cfg.GetImageFactory(), cfg.GetTalosVersion(), true)
 			}
 
 			upgradeFlags := []string{

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -18,7 +18,7 @@ import (
 // GenerateConfig takes `TalhelperConfig` and path to encrypted `secretFile` and generates
 // Talos `machineconfig` files and a `talosconfig` file in `outDir`.
 // It returns an error, if any.
-func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, mode string) error {
+func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, mode string, offlineMode bool) error {
 	var cfg []byte
 	input, err := talos.NewClusterInput(c, secretFile)
 	if err != nil {
@@ -29,7 +29,7 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 		fileName := c.ClusterName + "-" + node.Hostname + ".yaml"
 		cfgFile := outDir + "/" + fileName
 
-		cfg, err = talos.GenerateNodeConfigBytes(&node, input)
+		cfg, err = talos.GenerateNodeConfigBytes(&node, input, c.GetImageFactory(), offlineMode)
 		if err != nil {
 			return err
 		}

--- a/pkg/talos/nodeconfig_test.go
+++ b/pkg/talos/nodeconfig_test.go
@@ -81,12 +81,12 @@ nodes:
 		t.Fatal(err)
 	}
 
-	cp, err := GenerateNodeConfig(&m.Nodes[0], input)
+	cp, err := GenerateNodeConfig(&m.Nodes[0], input, m.GetImageFactory(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	w, err := GenerateNodeConfig(&m.Nodes[1], input)
+	w, err := GenerateNodeConfig(&m.Nodes[1], input, m.GetImageFactory(), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/talos/schematic.go
+++ b/pkg/talos/schematic.go
@@ -1,25 +1,95 @@
 package talos
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 	"strings"
+	"text/template"
 
+	"github.com/budimanjojo/talhelper/pkg/config"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
-func GetInstallerURL(cfg *schematic.Schematic, registryURL, version string) (string, error) {
-	id, err := cfg.ID()
-	if err != nil {
-		return "", err
-	}
-	return ensureSlashSuffix(registryURL) + id + ":" + version, nil
+var errNotStatusCreated = errors.New("Server not replying StatusCreated")
+
+type factoryPOSTResult struct {
+	ID string `json:"id"`
 }
 
-func GetISOURL(cfg *schematic.Schematic, registryURL, version, mode, arch string) (string, error) {
-	id, err := cfg.ID()
+type installerTmpl struct {
+	RegistryURL string
+	ID          string
+	Version     string
+}
+
+func GetInstallerURL(cfg *schematic.Schematic, factory *config.ImageFactory, version string, offlineMode bool) (string, error) {
+	tmplData := installerTmpl{
+		RegistryURL: factory.RegistryURL,
+		Version:     version,
+	}
+
+	id, err := getSchematicID(cfg, factory, offlineMode)
 	if err != nil {
 		return "", err
 	}
-	return ensureSlashSuffix(registryURL) + ensureSlashSuffix(id) + ensureSlashSuffix(version) + mode + "-" + arch + ".iso", nil
+	tmplData.ID = id
+
+	t, err := template.New("installer").Parse(factory.InstallerURLTmpl)
+	if err != nil {
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := t.Execute(buf, tmplData); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetISOURL(cfg *schematic.Schematic, registryURL, version, mode, arch string, offlineMode bool) (string, error) {
+	url := "https://" + ensureSlashSuffix(registryURL) + "image"
+	if offlineMode {
+		id, err := cfg.ID()
+		if err != nil {
+			return "", err
+		}
+		return ensureSlashSuffix(url) + ensureSlashSuffix(id) + ensureSlashSuffix(version) + mode + "-" + arch + ".iso", nil
+	}
+
+	body, err := cfg.Marshal()
+	if err != nil {
+		return "", err
+	}
+	var result factoryPOSTResult
+	schematicURL := "https://" + registryURL + "/schematics"
+	if err := doHTTPPOSTRequest(body, schematicURL, &result); err != nil {
+		return "", err
+	}
+	return ensureSlashSuffix(url) + ensureSlashSuffix(result.ID) + ensureSlashSuffix(version) + mode + "-" + arch + ".iso", nil
+}
+
+func getSchematicID(cfg *schematic.Schematic, iFactory *config.ImageFactory, offlineMode bool) (string, error) {
+	if offlineMode {
+		id, err := cfg.ID()
+		if err != nil {
+			return "", err
+		}
+		return id, nil
+	}
+	body, err := cfg.Marshal()
+	if err != nil {
+		return "", err
+	}
+	var resp factoryPOSTResult
+	schematicURL := iFactory.Protocol + "://" + iFactory.RegistryURL + iFactory.SchematicEndpoint
+	if err := doHTTPPOSTRequest(body, schematicURL, &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
 }
 
 func ensureSlashSuffix(s string) string {
@@ -27,4 +97,19 @@ func ensureSlashSuffix(s string) string {
 		return s
 	}
 	return s + "/"
+}
+
+func doHTTPPOSTRequest(body []byte, url string, out interface{}) error {
+	resp, err := http.Post(url, "", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("%w (%v): %v", errNotStatusCreated, url, resp.Status)
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/talos/schematic_test.go
+++ b/pkg/talos/schematic_test.go
@@ -1,25 +1,59 @@
 package talos
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/budimanjojo/talhelper/pkg/config"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
+
+func TestOnlineMode(t *testing.T) {
+	data := &schematic.Schematic{
+		Customization: schematic.Customization{
+			ExtraKernelArgs: []string{"net.ifnames=0"},
+			SystemExtensions: schematic.SystemExtensions{
+				OfficialExtensions: []string{"siderolabs/intel-ucode"},
+			},
+		},
+	}
+	jsonByte, err := data.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	onlineOut := map[string]string{}
+	if err := doHTTPPOSTRequest(jsonByte, "https://factory.talos.dev/schematics", &onlineOut); err != nil {
+		if errors.Is(err, errNotStatusCreated) {
+			t.Skipf("%v. Skipping this test...", err)
+		}
+		t.Fatal(err)
+	}
+	expectedID, err := data.ID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if onlineOut["id"] != expectedID {
+		t.Errorf("got %s, want %s", onlineOut["id"], expectedID)
+	}
+}
 
 func TestGetInstallerURL(t *testing.T) {
 	type testStruct struct {
 		name        string
 		cfg         *schematic.Schematic
-		registryURL string
+		iFactory    *config.ImageFactory
 		version     string
 		expectedURL string
 	}
 
 	for _, test := range []testStruct{
 		{
-			name:        "default",
-			cfg:         &schematic.Schematic{},
-			registryURL: "factory.talos.dev/installer",
+			name: "default",
+			cfg:  &schematic.Schematic{},
+			iFactory: &config.ImageFactory{
+				RegistryURL: "factory.talos.dev",
+			},
 			version:     "v1.5.4",
 			expectedURL: "factory.talos.dev/installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.5.4",
 		},
@@ -33,9 +67,11 @@ func TestGetInstallerURL(t *testing.T) {
 					},
 				},
 			},
-			registryURL: "",
+			iFactory: &config.ImageFactory{
+				RegistryURL: "",
+			},
 			version:     "v1.5.4",
-			expectedURL: "/98442b5bb4e8d050f30978ce3e6ec22e7bf534d57cafcd51313235128057e612:v1.5.4",
+			expectedURL: "factory.talos.dev/installer/98442b5bb4e8d050f30978ce3e6ec22e7bf534d57cafcd51313235128057e612:v1.5.4",
 		},
 
 		{
@@ -45,7 +81,8 @@ func TestGetInstallerURL(t *testing.T) {
 					ExtraKernelArgs: []string{"hihi", "hehe"},
 				},
 			},
-			expectedURL: "/ff5083b14ccb03821ea738d712ac08a82b44d2693013622059edaae286665239:",
+			iFactory:    &config.ImageFactory{},
+			expectedURL: "factory.talos.dev/installer/ff5083b14ccb03821ea738d712ac08a82b44d2693013622059edaae286665239:",
 		},
 
 		{
@@ -58,13 +95,17 @@ func TestGetInstallerURL(t *testing.T) {
 					ExtraKernelArgs: []string{"net.ifnames=0"},
 				},
 			},
-			registryURL: "test.registry/",
+			iFactory: &config.ImageFactory{
+				RegistryURL: "test.registry/",
+			},
 			version:     "1.5.4",
-			expectedURL: "test.registry/104c23dfe7c5bfeff6a4cc7e166d8b3bba0f371760592c7677c90c822bb1d109:1.5.4",
+			expectedURL: "test.registry//installer/104c23dfe7c5bfeff6a4cc7e166d8b3bba0f371760592c7677c90c822bb1d109:1.5.4",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			url, err := GetInstallerURL(test.cfg, test.registryURL, test.version)
+			cfg := &config.TalhelperConfig{}
+			cfg.ImageFactory = *test.iFactory
+			url, err := GetInstallerURL(test.cfg, cfg.GetImageFactory(), test.version, true)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/232

Because the image-factory server needs to know the requested schematic
id in order to be able to provide the image and ISO, we should do a HTTP
POST request to the server.

This will impact on the talhelper needing internet connection to work,
and this also mean it will prone to failure in case the server is down
or we can not establish connection with the image factory server.

So there's `--offline-mode` flag (disabled by default) added to some
commands to overcome this.
