### PR TITLE
Improve `genurl iso` subcommand

### DIFF
--- a/cmd/genurl_iso.go
+++ b/cmd/genurl_iso.go
@@ -48,7 +48,7 @@ var genurlISOCmd = &cobra.Command{
 				}
 
 				if node.IPAddress == genurlISONode {
-					url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
+					url, err := talos.GetISOURL(schema, cfg.GetImageFactory(), node.GetMachineSpec(), cfg.GetTalosVersion(), genurlISOOfflineMode)
 					if err != nil {
 						log.Fatalf("Failed to generate ISO url for %s, %v", node.Hostname, err)
 					}
@@ -56,7 +56,7 @@ var genurlISOCmd = &cobra.Command{
 					break
 				}
 
-				url, err := talos.GetISOURL(schema, genurlISORegistryURL, cfg.GetTalosVersion(), genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
+				url, err := talos.GetISOURL(schema, cfg.GetImageFactory(), node.GetMachineSpec(), cfg.GetTalosVersion(), genurlISOOfflineMode)
 				if err != nil {
 					log.Fatalf("Failed to generate ISO url for %s, %v", node.Hostname, err)
 				}
@@ -83,7 +83,9 @@ var genurlISOCmd = &cobra.Command{
 					},
 				},
 			}
-			url, err := talos.GetISOURL(cfg, genurlISORegistryURL, genurlISOVersion, genurlISOTalosMode, genurlISOArch, genurlISOOfflineMode)
+			tcfg := &config.TalhelperConfig{}
+			node := &config.Node{}
+			url, err := talos.GetISOURL(cfg, tcfg.GetImageFactory(), node.GetMachineSpec(), genurlISOVersion, genurlISOOfflineMode)
 			if err != nil {
 				log.Fatalf("Failed to generate installer url, %v", err)
 			}

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -184,6 +184,7 @@ imageFactory:
   schematicEndpoint: /schematics
   protocol: https
   installerURLTmpl: {{.RegistryURL}}/installer/{{.ID}}:{{.Version}}
+  ISOURLTmpl: {{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}/{{.Arch}}.iso
 ```
 </details></td>
 <td markdown="1" align="center">`nil`</td>
@@ -327,6 +328,20 @@ installDiskSelector:
   model: WDC*
   name: /sys/block/sda/device/name
   busPath: /pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`machineSpec`</td>
+<td markdown="1">[MachineSpec](#machinespec)</td>
+<td markdown="1"><details><summary>Machine hardware specification for the node.</summary>Only used for `genurl iso` subcommand.</details><details><summary>*Show example*</summary>
+```yaml
+machineSpec:
+  mode: metal
+  arch: arm64
 ```
 </summary></td>
 <td markdown="1" align="center">`nil`</td>
@@ -617,6 +632,53 @@ installerURLTmpl: "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}"
 ```
 </summary></td>
 <td markdown="1" align="center">`{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`ISOURLTmpl`</td>
+<td markdown="1">string</td>
+<td markdown="1"><details><summary>Go template to parse the full ISO image URL.</summary>Available placeholders: `Protocol`,`RegistryURL`,`ID`,`Version`,`Mode`,`Arch`</details><details><summary>*Show example*</summary>
+```yaml
+installerURLTmpl: "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso"
+```
+</summary></td>
+<td markdown="1" align="center">`{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+</table>
+
+## MachineSpec
+
+`MachineSpec` defines machine hardware configurations for a node.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`mode`</td>
+<td markdown="1">string</td>
+<td markdown="1">Machine mode.<details><summary>*Show example*</summary>
+```yaml
+mode: metal
+```
+</details></td>
+<td markdown="1" align="center">`"metal"`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`arch`</td>
+<td markdown="1">string</td>
+<td markdown="1">Machine architecture.<details><summary>*Show example*</summary>
+```yaml
+arch: arm64
+```
+</summary></td>
+<td markdown="1" align="center">`amd64`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,7 @@ type Node struct {
 	Patches             []string                          `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
 	TalosImageURL       string                            `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	Schematic           *schematic.Schematic              `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
+	MachineSpec         MachineSpec                       `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
 }
 
 type cniConfig struct {
@@ -71,4 +72,10 @@ type ImageFactory struct {
 	SchematicEndpoint string `yaml:"schematicEndpoint,omitempty" jsonschema:"default=/schematics,description:Endpoint to get schematic ID from the registry"`
 	Protocol          string `yaml:"protocol,omitempty" jsonschema:"default=https,description=Protocol of the registry(https or http)"`
 	InstallerURLTmpl  string `yaml:"installerURLTmpl,omitempty" jsonschema:"default={{.RegistryURL}}/installer/{{.ID}}:{{.Version}},description=Template for installer image URL"`
+	ISOURLTmpl        string `yaml:"ISOURLTmpl,omitempty" jsonschema:"default={{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso,description=Template for ISO image URL"`
+}
+
+type MachineSpec struct {
+	Mode string `yaml:"mode,omitempty" jsonschema:"default=metal,description=Machine mode (e.g: metal)"`
+	Arch string `yaml:"arch,omitempty" jsonschema:"default=amd64,description=Machine architecture (e.g: amd64, arm64)"`
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -87,11 +87,12 @@ func (c *TalhelperConfig) GetInstallerURL() string {
 
 // GetImageFactory returns default `imageFactory` if not specified.
 func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
-	result := ImageFactory{
+	result := &ImageFactory{
 		RegistryURL:       "factory.talos.dev",
 		SchematicEndpoint: "/schematics",
 		Protocol:          "https",
 		InstallerURLTmpl:  "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}",
+		ISOURLTmpl:        "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso",
 	}
 	if c.ImageFactory.RegistryURL != "" {
 		result.RegistryURL = c.ImageFactory.RegistryURL
@@ -105,7 +106,22 @@ func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
 	if c.ImageFactory.InstallerURLTmpl != "" {
 		result.InstallerURLTmpl = c.ImageFactory.InstallerURLTmpl
 	}
-	return &result
+	return result
+}
+
+// GetMachineSpec returns default `MachineSpec` for `Node` if not specified.
+func (n *Node) GetMachineSpec() *MachineSpec {
+	result := &MachineSpec{
+		Mode: "metal",
+		Arch: "amd64",
+	}
+	if n.MachineSpec.Mode != "" {
+		result.Mode = n.MachineSpec.Mode
+	}
+	if n.MachineSpec.Arch != "" {
+		result.Arch = n.MachineSpec.Arch
+	}
+	return result
 }
 
 // endpointisIPv6 returns true if string is IPv6 address.


### PR DESCRIPTION
This adds per node `machineSpec` that will be used to get ISO image URL
from the registry. For example, you can have a node like this:

```
nodes:
  - hostname: node1
    machineSpec:
      mode: metal
      arch: arm64
```

Doing `talhelper genurl iso` from the directory where talconfig.yaml is
found will generate the url to download ISO image for that node.