### PR TITLE
feat(genconfig): add extraKernelArgs to machine.install.extraKernelArgs

### DIFF
--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -96,6 +96,10 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineFiles = node.MachineFiles
 	}
 
+	if len(node.Schematic.Customization.ExtraKernelArgs) > 0 {
+		cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs = append(cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs, node.Schematic.Customization.ExtraKernelArgs...)
+	}
+
 	return cfg
 }
 

--- a/pkg/talos/nodeconfig_test.go
+++ b/pkg/talos/nodeconfig_test.go
@@ -129,6 +129,7 @@ nodes:
 		},
 	}
 	expectedNode1InstallImage := "factory.talos.dev/installer/647a0a54bff662aa12051bc0312097f29d3562107d8e6a8e87ab85b643e25bc0:v1.5.4"
+	expectedNode1InstallExtraKernelArgs := []string{"hello", "hihi"}
 	expectedNode2Type := "worker"
 	expectedNode2InstallDiskSelector := &v1alpha1.InstallDiskSelector{
 		Size: &v1alpha1.InstallDiskSizeMatcher{
@@ -167,6 +168,7 @@ nodes:
 	compare(cpCfg.MachineNetwork.NetworkInterfaces, expectedNode1NetworkInterfaces, t)
 	compare(cpCfg.MachineKernel, expectedNode1KernelModules, t)
 	compare(cpCfg.MachineInstall.InstallImage, expectedNode1InstallImage, t)
+	compare(cpCfg.MachineInstall.ExtraKernelArgs(), expectedNode1InstallExtraKernelArgs, t)
 	compare(wCfg.MachineType, expectedNode2Type, t)
 	compare(wCfg.MachineInstall.InstallDiskSelector, expectedNode2InstallDiskSelector, t)
 	compare(wCfg.MachineDisks, expectedNode2MachineDisks, t)


### PR DESCRIPTION
It makes more sense because you should expect them to be loaded if you
define schematic that has them. By default installer image ignores
kernel args so they will not be loaded unless you define them in your
machine configs at `machine.install.extraKernelArgs`.

Ref: https://www.talos.dev/v1.5/learn-more/image-factory/#restrictions

Fixes: https://github.com/budimanjojo/talhelper/issues/243
