### PR TITLE
fix(ci): Fix docker build workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -52,20 +52,21 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=false,name-canonical=true,push=false
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        id: export
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
+          echo "digest=${digest#sha256:}" | tee $GITHUB_OUTPUT
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: ${{ steps.export.outputs.digest }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -77,7 +78,6 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
           path: /tmp/digests
 
       - name: Set up Docker Buildx
@@ -99,9 +99,11 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          IMAGES=$(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker buildx imagetools create $TAGS $IMAGES
 
       - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+        env:
+          IMAGE: "${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}"
+        run: docker buildx imagetools inspect $IMAGE


### PR DESCRIPTION
These 2 renovate PRs are upgrading the upload/download-artifact action from v3 to v4:

- https://github.com/budimanjojo/talhelper/commit/24c6431bf5f47b570991a23b8e50068cdadd6653
- https://github.com/budimanjojo/talhelper/commit/3a05d6304036c8d28d0149bd3cab57fd3bee4aa0

And there are breaking changes for v4: https://github.com/actions/upload-artifact#breaking-changes

This PR fixes the issues (and does a tiny bit of cleanup on the workflow file as well).

Successful job: https://github.com/mirceanton/talhelper/actions/runs/7247675983/job/19742395789