### PR TITLE
Fix parsing of image-digests from docker manifest

### DIFF
--- a/hack/tsehelper/tags.go
+++ b/hack/tsehelper/tags.go
@@ -77,6 +77,10 @@ func cleanString(line string) string {
 
 	// Find the sub-matches
 	matches := regexp.FindStringSubmatch(line)
+	if len(matches) == 0 {
+		log.Tracef("no matches found for line: %s", line)
+		return ""
+	}
 	log.Tracef("regexp matches: %s", matches)
 
 	// Map results to capture group names

--- a/hack/tsehelper/tar_archive.go
+++ b/hack/tsehelper/tar_archive.go
@@ -12,11 +12,10 @@ import (
 func processTarArchive(tarData []byte) ([]string, error) {
 	// Create a new reader from the tar data
 	tarReader := tar.NewReader(bytes.NewReader(tarData))
-
 	// Iterate through the files in the tar archive
 	var exts []string
 	for {
-		_, err := tarReader.Next()
+		header, err := tarReader.Next()
 		if err == io.EOF {
 			// End of tar archive
 			break
@@ -24,20 +23,25 @@ func processTarArchive(tarData []byte) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		var fileContent bytes.Buffer
-		_, err = io.Copy(&fileContent, tarReader)
-		if err != nil {
-			return nil, err
-		}
-		// Process the file content, split by new line
-		lines := strings.Split(fileContent.String(), "\n")
 
-		for _, line := range lines {
-			// Skip empty lines
-			if line == "" {
-				continue
+		// Check if the current entry matches the target filename
+		targetFilename := "image-digests"
+		if header.Name == targetFilename {
+			// Read the content of the file
+			content := make([]byte, header.Size)
+			_, err := tarReader.Read(content)
+			if err != io.EOF {
+				return nil, err
 			}
-			exts = append(exts, line)
+			// Process the file content, split by new line
+			lines := strings.Split(string(content), "\n")
+			for _, line := range lines {
+				// Skip empty lines
+				if line == "" {
+					continue
+				}
+				exts = append(exts, line)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the parsing of the Docker manifest by searching for the file named `image-digests` and parsing that specifically.