### PR TITLE
feat(config): supports firewall configuration for nodes

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -349,6 +349,28 @@ machineSpec:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`ingressFirewall`</td>
+<td markdown="1">[IngressFirewall](#ingressfirewall)</td>
+<td markdown="1">Machine firewall specification for the node.<details><summary>*Show example*</summary>
+```yaml
+ingressFirewall:
+  defaultAction: block
+  rules:
+    - name: kubelet-ingress
+      portSelector:
+        ports:
+          - 10250
+        protocol: tcp
+      ingress:
+        - subnet: 172.20.0.0/24
+          except: 172.20.0.1/32
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`controlPlane`</td>
 <td markdown="1">bool</td>
 <td markdown="1">Whether the node is a controlplane.<details><summary>*Show example*</summary>
@@ -671,6 +693,101 @@ arch: arm64
 
 </table>
 
+## IngressFirewall
+
+`IngressFirewall` defines machine firewall configuration for a node.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`defaultAction`</td>
+<td markdown="1">`string`</td>
+<td markdown="1"><details><summary>Default action for all not explicitly configured traffic.</summary>Can be "accept" or "block"</details><details><summary>*Show example*</summary>
+```yaml
+defaultAction: accept
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`rules`</td>
+<td markdown="1">[][NetworkRule](#networkrule)</td>
+<td markdown="1"><details><summary>List of matching network rules to allow or block against the defaultAction.</summary>If `defaultAction` is set to block, matching rules will be allowed vice versa.</details><details><summary>*Show example*</summary>
+```yaml
+rules:
+  - name: kubelet-ingress
+    portSelector:
+      ports:
+        - 10250
+      protocol: tcp
+    ingress:
+      - subnet: 172.20.0.0/24
+        except: 172.20.0.1/32
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+</table>
+
+## NetworkRule
+
+`NetworkRule` defines the firewall rules to match.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`name`</td>
+<td markdown="1">`string`</td>
+<td markdown="1">Name of the rule.<details><summary>*Show example*</summary>
+```yaml
+name: kubelet-ingress
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`portSelector`</td>
+<td markdown="1">[PortSelector](#portselector)</td>
+<td markdown="1">Ports and protocols on the host affected by the rule.<details><summary>*Show example*</summary>
+```yaml
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`ingress`</td>
+<td markdown="1">[][IngressConfig](#ingressconfig)</td>
+<td markdown="1">List of source subnets allowed to access the host ports/protocols.<details><summary>*Show example*</summary>
+```yaml
+ingress:
+  - subnet: 172.20.0.0/24
+    except: 172.20.0.1/32
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+</table>
+
 ## ControlPlane
 
 `ControlPlane` defines machine configurations for controlplane type nodes.
@@ -870,3 +987,11 @@ schematic:
 ## Device
 
 `Device` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/#device" target="_blank">`v1alpha1.Device`</a>
+
+## PortSelector
+
+`PortSelector` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/network/networkruleconfig/#NetworkRuleConfig.portSelector" target="_blank">`network.RulePortSelector`</a>
+
+## IngressConfig
+
+`IngressConfig` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/network/networkruleconfig/#NetworkRuleConfig.ingress" target="_blank">`network.IngressConfig`</a>

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -25,6 +25,17 @@ patches:
         GRPC_GO_LOG_SEVERITY_LEVEL: error
 nodes:
   - hostname: kmaster1
+    ingressFirewall:
+      defaultAction: block
+      rules:
+        - name: kubelet-ingress
+          portSelector:
+            ports:
+              - 10250
+            protocol: tcp
+          ingress:
+            - subnet: 172.20.0.0/24
+              except: 172.20.0.1/32
     ipAddress: 192.168.200.11
     controlPlane: true
     schematic:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"github.com/siderolabs/image-factory/pkg/schematic"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 )
 
 type TalhelperConfig struct {
@@ -47,6 +49,7 @@ type Node struct {
 	TalosImageURL       string                            `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	Schematic           *schematic.Schematic              `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
 	MachineSpec         MachineSpec                       `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
+	IngressFirewall     *IngressFirewall                  `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 }
 
 type controlPlane struct {
@@ -74,4 +77,15 @@ type ImageFactory struct {
 type MachineSpec struct {
 	Mode string `yaml:"mode,omitempty" jsonschema:"default=metal,description=Machine mode (e.g: metal)"`
 	Arch string `yaml:"arch,omitempty" jsonschema:"default=amd64,description=Machine architecture (e.g: amd64, arm64)"`
+}
+
+type IngressFirewall struct {
+	DefaultAction nethelpers.DefaultAction `yaml:"defaultAction,omitempty" jsonschema:"default=block,description=Default action for all not explicitly configured traffic"`
+	NetworkRules  []NetworkRule            `yaml:"rules,omitempty" jsonschema:"description=List of matching network rules to allow or block against the defaultAction"`
+}
+
+type NetworkRule struct {
+	Name         string                   `yaml:"name" jsonschema:"description=Name of the rule"`
+	PortSelector network.RulePortSelector `yaml:"portSelector" jsonschema:"description=Ports and protocols on the host affected by the rule"`
+	Ingress      network.IngressConfig    `yaml:"ingress" jsonschema:"description=List of source subnets allowed to access the host ports/protocols"`
 }

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -12,9 +12,34 @@ type InstallDiskSelectorWrapper struct {
 	BusPath  string `yaml:"busPath" jsonschema:"Disk bus path"`
 }
 
+type IngressFirewallWrapper struct {
+	DefaultAction string               `yaml:"defaultAction" jsonschema:"default=block,description=Default action for all not explicitly configured traffic"`
+	NetworkRules  []NetworkRuleWrapper `yaml:"rules" jsonschema:"description=List of matching network rules to allow or block against the defaultAction"`
+}
+
+type NetworkRuleWrapper struct {
+	Name         string                 `yaml:"name" jsonschema:"description=Name of the rule"`
+	PortSelector PortSelectorWrapper    `yaml:"portSelector" jsonschema:"description=Ports and protocols on the host affected by the rule"`
+	Ingress      []IngressConfigWrapper `yaml:"ingress" jsonschema:"description=List of source subnets allowed to access the host ports/protocols"`
+}
+
+type PortSelectorWrapper struct {
+	Ports    []any  `yaml:"ports" jsonschema:"description=List of ports or port ranges"`
+	Protocol string `yaml:"protocol" jsonschema:"description=Protocol (can be tcp or udp)"`
+}
+
+type IngressConfigWrapper struct {
+	Subnet string `yaml:"subnet" jsonschema:"description=Source subnet"`
+	Except string `yaml:"except" jsonschema:"description=Source subnet to exclude from the subnet"`
+}
+
 func (Node) JSONSchemaProperty(prop string) any {
 	if prop == "installDiskSelector" {
 		return &InstallDiskSelectorWrapper{}
 	}
 	return nil
+}
+
+func (IngressFirewall) JSONSchemaAlias() any {
+	return &IngressFirewallWrapper{}
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -59,6 +59,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeNameServers(node, k, &result)
 		checkNodeNetworkInterfaces(node, k, &result)
 		checkNodeConfigPatches(node, k, &result)
+		checkNodeIngressFirewall(node, k, &result)
 	}
 	return result, warns
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -35,6 +35,17 @@ nodes:
     configPatches:
       - op: del
         path: /cluster
+    firewallSpec:
+      ingress:
+        defaultAction: block
+        rules:
+          - name: kubelet-ingress
+            portSelector:
+              ports:
+                - 10250
+              protocol: tcp
+            ingress:
+              - subnet: 172.20.0.0/24
   - nodeLabels:
       ra*ck: rack1a
       z***: hahaha
@@ -67,6 +78,7 @@ nodes:
 		"nodes[0].controlPlane":      false,
 		"nodes[0].installDisk":       false,
 		"nodes[0].nameservers":       false,
+		"nodes[0].firewallSpec":      false,
 		"nodes[0].networkInterfaces": true,
 		"nodes[0].configPatches":     true,
 		"nodes[1].hostname":          true,

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -19,13 +19,14 @@ import (
 // Talos `machineconfig` files and a `talosconfig` file in `outDir`.
 // It returns an error, if any.
 func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, mode string, offlineMode bool) error {
-	var cfg []byte
 	input, err := talos.NewClusterInput(c, secretFile)
 	if err != nil {
 		return err
 	}
 
 	for _, node := range c.Nodes {
+		var cfg []byte
+
 		fileName := c.ClusterName + "-" + node.Hostname + ".yaml"
 		cfgFile := outDir + "/" + fileName
 
@@ -98,6 +99,14 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 		cfg, err = talos.ReEncodeTalosConfig(cfg)
 		if err != nil {
 			return err
+		}
+
+		if node.IngressFirewall != nil {
+			nc, err := talos.GenerateNodeNetworkConfigBytes(&node)
+			if err != nil {
+				return err
+			}
+			cfg = append(cfg, nc...)
 		}
 
 		if !dryRun {

--- a/pkg/talos/networkconfig.go
+++ b/pkg/talos/networkconfig.go
@@ -1,0 +1,88 @@
+package talos
+
+import (
+	"bytes"
+
+	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateNodeNetworkConfigBytes(node *config.Node) ([]byte, error) {
+	var result [][]byte
+
+	defaultAction := GenerateNodeDefaultActionConfig(node)
+	defaultActionBytes, err := marshalYaml(defaultAction)
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result, defaultActionBytes)
+
+	rules, err := GenerateNodeRuleConfig(node)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range rules {
+		ruleBytes, err := marshalYaml(rule)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, ruleBytes)
+	}
+
+	return combineYamlBytes(result), nil
+}
+
+func GenerateNodeDefaultActionConfig(node *config.Node) *network.DefaultActionConfigV1Alpha1 {
+	result := network.NewDefaultActionConfigV1Alpha1()
+	result.Ingress = node.IngressFirewall.DefaultAction
+
+	return result
+}
+
+func GenerateNodeRuleConfig(node *config.Node) ([]*network.RuleConfigV1Alpha1, error) {
+	var result []*network.RuleConfigV1Alpha1
+
+	for _, v := range node.IngressFirewall.NetworkRules {
+		rule := network.NewRuleConfigV1Alpha1()
+		rule.MetaName = v.Name
+		rule.PortSelector = v.PortSelector
+		rule.Ingress = v.Ingress
+
+		if _, err := rule.Validate(nil); err != nil {
+			return nil, err
+		}
+
+		result = append(result, rule)
+	}
+
+	return result, nil
+}
+
+// marshalYaml encodes `in` into `yaml` bytes with 2 indentation.
+// It also returns an error, if any.
+func marshalYaml(in interface{}) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	encoder := yaml.NewEncoder(buf)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(in); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// combineYamlBytes prepends and returns `---\n` before `input`
+func combineYamlBytes(input [][]byte) []byte {
+	delimiter := []byte("---\n")
+	var result []byte
+	for k := range input {
+		result = append(result, delimiter...)
+		result = append(result, input[k]...)
+	}
+	return result
+}

--- a/pkg/talos/networkconfig_test.go
+++ b/pkg/talos/networkconfig_test.go
@@ -1,0 +1,96 @@
+package talos
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGenerateNodeDefaultActionConfig(t *testing.T) {
+	data := []byte(`nodes:
+  - hostname: node1
+    ingressFirewall:
+      defaultAction: accept
+  - hostname: node2
+    ingressFirewall:
+      defaultAction: block`)
+
+	var m config.TalhelperConfig
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	node1Result := GenerateNodeDefaultActionConfig(&m.Nodes[0])
+	node2Result := GenerateNodeDefaultActionConfig(&m.Nodes[1])
+
+	compare(node1Result.Ingress.String(), "accept", t)
+	compare(node2Result.Ingress.String(), "block", t)
+}
+
+func TestGenerateNodeRuleConfig(t *testing.T) {
+	data := []byte(`nodes:
+  - hostname: node1
+    ingressFirewall:
+      defaultAction: accept
+      rules:
+        - name: kubelet-ingress
+          portSelector:
+            ports:
+              - 10250
+            protocol: tcp
+          ingress:
+            - subnet: 172.20.0.0/24
+              except: 172.20.0.1/32
+        - name: etcd-ingress
+          portSelector:
+            ports:
+              - 2379-2380
+            protocol: tcp
+          ingress:
+            - subnet: 10.10.10.1/32
+            - subnet: 10.10.10.2/32
+            - subnet: 10.10.10.3/32`)
+
+	var m config.TalhelperConfig
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRule1Name := "kubelet-ingress"
+	expectedRule1PortSelector := network.RulePortSelector{
+		Ports:    network.PortRanges{network.PortRange{Lo: 10250, Hi: 10250}},
+		Protocol: nethelpers.ProtocolTCP,
+	}
+	expectedRule1Ingress := network.IngressConfig{
+		{
+			Subnet: netip.MustParsePrefix("172.20.0.0/24"),
+			Except: network.Prefix{Prefix: netip.MustParsePrefix("172.20.0.1/32")},
+		},
+	}
+	expectedRule2Name := "etcd-ingress"
+	expectedRule2PortSelector := network.RulePortSelector{
+		Ports:    network.PortRanges{network.PortRange{Lo: 2379, Hi: 2380}},
+		Protocol: nethelpers.ProtocolTCP,
+	}
+	expectedRule2Ingress := network.IngressConfig{
+		{Subnet: netip.MustParsePrefix("10.10.10.1/32")},
+		{Subnet: netip.MustParsePrefix("10.10.10.2/32")},
+		{Subnet: netip.MustParsePrefix("10.10.10.3/32")},
+	}
+
+	result, err := GenerateNodeRuleConfig(&m.Nodes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compare(result[0].Name(), expectedRule1Name, t)
+	compare(result[0].PortSelector, expectedRule1PortSelector, t)
+	compare(result[0].Ingress, expectedRule1Ingress, t)
+	compare(result[1].Name(), expectedRule2Name, t)
+	compare(result[1].PortSelector, expectedRule2PortSelector, t)
+	compare(result[1].Ingress, expectedRule2Ingress, t)
+}


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/284

This allows you to have something like this in your `talconfig.yaml`:

```
nodes:
  - firewallSpec:
      ingress:
        defaultAction: block
        rules:
          - name: kubelet-ingress
            portSelector:
              ports:
                - 10250
              protocol: tcp
            ingress:
              - subnet: 172.20.0.0/24
                except: 172.20.0.1/32
```

And it will then create something like this appended in the generated
manifest for the node that you can apply using `talosctl`:

```
apiVersion: v1alpha1
kind: NetworkDefaultActionConfig
ingress: block
---
apiVersion: v1alpha1
kind: NetworkRuleConfig
name: kubelet-ingress
portSelector:
  ports:
    - 10250
  protocol: tcp
ingress:
  - subnet: 172.20.0.0/24
    except: 172.20.0.1/32
```

Ref: https://www.talos.dev/v1.6/talos-guides/network/ingress-firewall/
