### PR TITLE
feat(config): supports extra manifests for nodes

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -531,6 +531,20 @@ networkInterfaces:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`extraManifests`</td>
+<td markdown="1">[]string</td>
+<td markdown="1">List of manifest files to be added for the node.<details><summary>*Show example*</summary>
+```yaml
+extraManifests:
+  - etcd-firewall.yaml
+  - kubelet-firewall.yaml
+```
+</summary></td>
+<td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`patches`</td>
 <td markdown="1">[]string</td>
 <td markdown="1"><details><summary>Patches to be applied to the node.</summary>List of strings containing RFC6902 JSON patches, strategic merge patches,<br />or a file containing them.</details><details><summary>*Show example*</summary>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Node struct {
 	KernelModules       []*v1alpha1.KernelModuleConfig    `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
 	Nameservers         []string                          `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
 	NetworkInterfaces   []*v1alpha1.Device                `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
+	ExtraManifests      []string                          `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
 	ConfigPatches       []map[string]interface{}          `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	InlinePatch         map[string]interface{}            `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
 	Patches             []string                          `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -32,8 +32,8 @@ func ValidateFromFile(path string) (Errors, Warnings, error) {
 	return runValidate(byte)
 }
 
-// Validate returns `Errors` if the given `TalhelperConfig` is not
-// correct
+// Validate returns `Errors` and `Warnings` if the given
+// `TalhelperConfig` is not correct
 func (c TalhelperConfig) Validate() (Errors, Warnings) {
 	var result Errors
 	var warns Warnings
@@ -60,6 +60,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeNetworkInterfaces(node, k, &result)
 		checkNodeConfigPatches(node, k, &result)
 		checkNodeIngressFirewall(node, k, &result)
+		checkNodeExtraManifests(node, k, &result)
 	}
 	return result, warns
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -58,6 +58,8 @@ nodes:
         systemExtensions:
           officialExtensions:
             - siderolabs/aaa
+    extraManifests:
+     - test.yaml
 `)
 
 	errs, warns, err := ValidateFromByte(data)
@@ -88,6 +90,7 @@ nodes:
 		"nodes[1].nodeTaints":        true,
 		"nodes[1].machineFiles":      true,
 		"nodes[1].schematic":         true,
+		"nodes[1].extraManifests":    true,
 	}
 
 	expectedWarnings := map[string]bool{

--- a/pkg/talos/networkconfig.go
+++ b/pkg/talos/networkconfig.go
@@ -33,7 +33,7 @@ func GenerateNodeNetworkConfigBytes(node *config.Node) ([]byte, error) {
 		result = append(result, ruleBytes)
 	}
 
-	return combineYamlBytes(result), nil
+	return CombineYamlBytes(result), nil
 }
 
 func GenerateNodeDefaultActionConfig(node *config.Node) *network.DefaultActionConfigV1Alpha1 {
@@ -76,8 +76,8 @@ func marshalYaml(in interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// combineYamlBytes prepends and returns `---\n` before `input`
-func combineYamlBytes(input [][]byte) []byte {
+// CombineYamlBytes prepends and returns `---\n` before `input`
+func CombineYamlBytes(input [][]byte) []byte {
 	delimiter := []byte("---\n")
 	var result []byte
 	for k := range input {


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/291

This allows you to have something like this in your `talconfig.yaml`:

```yaml
nodes:
  - extraManifests:
      - etcd-firewall.yaml
      - kubelet-firewall.yaml
      - ../anotherfile.yaml
```

And the content of those files will be appended in the generated
manifest for the node that you can apply using `talosctl` like so:

```yaml
<generated machineconfig>
---
<etcd-firewall.yaml content>
---
<kubelet-firewall.yaml content>
---
<../anotherfile.yaml content>
```

This is made to prepare for
https://github.com/siderolabs/talos/issues/7223
