### PR TITLE
feat(config): add node groups `ingressFirewall` and `extraManifests`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -884,6 +884,42 @@ schematic:
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
+<tr markdown="1">
+<td markdown="1">`ingressFirewall`</td>
+<td markdown="1">[IngressFirewall](#ingressfirewall)</td>
+<td markdown="1">Firewall specification for all controlplane nodes.<details><summary>*Show example*</summary>
+```yaml
+ingressFirewall:
+  defaultAction: block
+  rules:
+    - name: kubelet-ingress
+      portSelector:
+        ports:
+          - 10250
+        protocol: tcp
+      ingress:
+        - subnet: 172.20.0.0/24
+          except: 172.20.0.1/32
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`extraManifests`</td>
+<td markdown="1">[]string</td>
+<td markdown="1">List of manifest files to be added to all controlplane nodes.<details><summary>*Show example*</summary>
+```yaml
+extraManifests:
+  - etcd-firewall.yaml
+  - kubelet-firewall.yaml
+```
+</summary></td>
+<td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
 </table>
 
 ## Worker
@@ -965,6 +1001,42 @@ schematic:
 ```
 </summary></td>
 <td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`ingressFirewall`</td>
+<td markdown="1">[IngressFirewall](#ingressfirewall)</td>
+<td markdown="1">Firewall specification for all worker nodes.<details><summary>*Show example*</summary>
+```yaml
+ingressFirewall:
+  defaultAction: block
+  rules:
+    - name: kubelet-ingress
+      portSelector:
+        ports:
+          - 10250
+        protocol: tcp
+      ingress:
+        - subnet: 172.20.0.0/24
+          except: 172.20.0.1/32
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`extraManifests`</td>
+<td markdown="1">[]string</td>
+<td markdown="1">List of manifest files to be added to all worker nodes.<details><summary>*Show example*</summary>
+```yaml
+extraManifests:
+  - etcd-firewall.yaml
+  - kubelet-firewall.yaml
+```
+</summary></td>
+<td markdown="1" align="center">`[]`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -128,6 +128,16 @@ controlPlane:
           rotate-server-certificates: "true"
     - "@./extraKernelArgs-patch.yaml"
 worker:
+  ingressFirewall:
+    defaultAction: block
+    rules:
+      - name: apid-ingress
+        portSelector:
+          ports:
+            - 50000
+          protocol: tcp
+        ingress:
+          - subnet: 10.96.0.0/12
   patches:
     - |-
       - op: add

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,17 +54,21 @@ type Node struct {
 }
 
 type controlPlane struct {
-	ConfigPatches []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	InlinePatch   map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	Patches       []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all controlplane nodes"`
-	Schematic     *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all controlplane nodes"`
+	ConfigPatches   []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
+	InlinePatch     map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
+	Patches         []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all controlplane nodes"`
+	Schematic       *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all controlplane nodes"`
+	IngressFirewall *IngressFirewall         `yaml:"ingressFirewall,omitempty" jsonschema:"description=Firewall specification for all controlplane nodes"`
+	ExtraManifests  []string                 `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to all controlplane nodes"`
 }
 
 type worker struct {
-	ConfigPatches []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	InlinePatch   map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	Patches       []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all worker nodes"`
-	Schematic     *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all worker nodes"`
+	ConfigPatches   []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
+	InlinePatch     map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
+	Patches         []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all worker nodes"`
+	Schematic       *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all worker nodes"`
+	IngressFirewall *IngressFirewall         `yaml:"ingressFirewall,omitempty" jsonschema:"description=Firewall specification for all worker nodes"`
+	ExtraManifests  []string                 `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to all worker nodes"`
 }
 
 type ImageFactory struct {

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -16,6 +16,18 @@ clusterPodNets:
 clusterSvcNets:
   - 10.244.0.0/16
   - 10.10.0.0/166
+controlPlane:
+  ingressFirewall:
+    defaultAction: block
+    rules:
+      - portSelector:
+          ports:
+            - 10250
+        ingress:
+          - subnet: 172.20.0.0/24
+worker:
+  extraManifests:
+    - test.yaml
 nodes:
   - hostname: master1
     ipAddress: 1.2.3.4.5
@@ -35,17 +47,16 @@ nodes:
     configPatches:
       - op: del
         path: /cluster
-    firewallSpec:
-      ingress:
-        defaultAction: block
-        rules:
-          - name: kubelet-ingress
-            portSelector:
-              ports:
-                - 10250
-              protocol: tcp
-            ingress:
-              - subnet: 172.20.0.0/24
+    ingressFirewall:
+      defaultAction: block
+      rules:
+        - name: kubelet-ingress
+          portSelector:
+            ports:
+              - 10250
+            protocol: tcp
+          ingress:
+            - subnet: 172.20.0.0/24
   - nodeLabels:
       ra*ck: rack1a
       z***: hahaha
@@ -68,29 +79,31 @@ nodes:
 	}
 
 	expectedErrors := map[string]bool{
-		"clusterName":                false,
-		"talosVersion":               true,
-		"kubernetesVersion":          true,
-		"endpoint":                   true,
-		"cniConfig":                  true,
-		"clusterPodNets":             false,
-		"clusterSvcNets":             true,
-		"nodes[0].hostname":          false,
-		"nodes[0].ipAddress":         false,
-		"nodes[0].controlPlane":      false,
-		"nodes[0].installDisk":       false,
-		"nodes[0].nameservers":       false,
-		"nodes[0].firewallSpec":      false,
-		"nodes[0].networkInterfaces": true,
-		"nodes[0].configPatches":     true,
-		"nodes[1].hostname":          true,
-		"nodes[1].ipAddress":         true,
-		"nodes[1].installDisk":       true,
-		"nodes[1].nodeLabels":        true,
-		"nodes[1].nodeTaints":        true,
-		"nodes[1].machineFiles":      true,
-		"nodes[1].schematic":         true,
-		"nodes[1].extraManifests":    true,
+		"clusterName":                  false,
+		"talosVersion":                 true,
+		"kubernetesVersion":            true,
+		"endpoint":                     true,
+		"cniConfig":                    true,
+		"clusterPodNets":               false,
+		"clusterSvcNets":               true,
+		"controlPlane.ingressFirewall": true,
+		"worker.extraManifests":        true,
+		"nodes[0].hostname":            false,
+		"nodes[0].ipAddress":           false,
+		"nodes[0].controlPlane":        false,
+		"nodes[0].installDisk":         false,
+		"nodes[0].nameservers":         false,
+		"nodes[0].ingressFirewall":     false,
+		"nodes[0].networkInterfaces":   true,
+		"nodes[0].configPatches":       true,
+		"nodes[1].hostname":            true,
+		"nodes[1].ipAddress":           true,
+		"nodes[1].installDisk":         true,
+		"nodes[1].nodeLabels":          true,
+		"nodes[1].nodeTaints":          true,
+		"nodes[1].machineFiles":        true,
+		"nodes[1].schematic":           true,
+		"nodes[1].extraManifests":      true,
 	}
 
 	expectedWarnings := map[string]bool{

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -203,6 +203,26 @@ func checkControlPlane(c TalhelperConfig, result *Errors) *Errors {
 			})
 		}
 	}
+
+	if c.ControlPlane.IngressFirewall != nil {
+		if err := checkIngressFirewall(c.ControlPlane.IngressFirewall); err != nil {
+			result = result.Append(&Error{
+				Kind:    "InvalidControlPlaneIngressFirewall",
+				Field:   getFieldYamlTag(c, "ControlPlane.IngressFirewall"),
+				Message: formatError(multierror.Append(err)),
+			})
+		}
+	}
+
+	if len(c.ControlPlane.ExtraManifests) > 0 {
+		if err := checkExtraManifests(c.ControlPlane.ExtraManifests); err != nil {
+			result = result.Append(&Error{
+				Kind:    "InvalidControlPlaneExtraManifests",
+				Field:   getFieldYamlTag(c, "ControlPlane.ExtraManifests"),
+				Message: formatError(multierror.Append(err)),
+			})
+		}
+	}
 	return result
 }
 
@@ -213,6 +233,26 @@ func checkWorker(c TalhelperConfig, result *Errors) *Errors {
 				Kind:    "InvalidWorkerConfigPatches",
 				Field:   getFieldYamlTag(c, "Worker.ConfigPatches"),
 				Message: formatError(multierror.Append(fmt.Errorf("doesn't look like list of RFC6902 JSON patches"))),
+			})
+		}
+	}
+
+	if c.Worker.IngressFirewall != nil {
+		if err := checkIngressFirewall(c.Worker.IngressFirewall); err != nil {
+			result = result.Append(&Error{
+				Kind:    "InvalidWorkerIngressFirewall",
+				Field:   getFieldYamlTag(c, "Worker.IngressFirewall"),
+				Message: formatError(multierror.Append(err)),
+			})
+		}
+	}
+
+	if len(c.Worker.ExtraManifests) > 0 {
+		if err := checkExtraManifests(c.Worker.ExtraManifests); err != nil {
+			result = result.Append(&Error{
+				Kind:    "InvalidWorkerExtraManifests",
+				Field:   getFieldYamlTag(c, "Worker.ExtraManifests"),
+				Message: formatError(multierror.Append(err)),
 			})
 		}
 	}
@@ -513,40 +553,7 @@ func checkNodeConfigPatches(node Node, idx int, result *Errors) *Errors {
 
 func checkNodeIngressFirewall(node Node, idx int, result *Errors) *Errors {
 	if node.IngressFirewall != nil {
-		var messages *multierror.Error
-
-		if len(node.IngressFirewall.NetworkRules) > 0 {
-			for k, v := range node.IngressFirewall.NetworkRules {
-				if v.Name == "" {
-					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: name is required", k))
-				}
-
-				if !v.PortSelector.Protocol.IsAProtocol() {
-					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: %q is not a valid protocol", k, v.PortSelector.Protocol))
-				}
-
-				if len(v.PortSelector.Ports) == 0 {
-					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: portSelector.ports is required", k))
-				}
-
-				if err := v.PortSelector.Ports.Validate(); err != nil {
-					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: %q", k, err))
-				}
-
-				for _, rule := range v.Ingress {
-					if !rule.Subnet.IsValid() {
-						messages = multierror.Append(messages, fmt.Errorf("rules[%d]: invalid subnet: %s", k, rule.Subnet))
-					}
-					if !rule.Except.IsZero() && !rule.Except.IsValid() {
-						messages = multierror.Append(messages, fmt.Errorf("rules[%d]: invalid except: %s", k, rule.Except))
-					}
-				}
-			}
-		}
-		if !node.IngressFirewall.DefaultAction.IsADefaultAction() {
-			messages = multierror.Append(messages, fmt.Errorf("%q is not a valid default action", node.IngressFirewall.DefaultAction))
-		}
-
+		messages := checkIngressFirewall(node.IngressFirewall)
 		if messages.ErrorOrNil() != nil {
 			return result.Append(&Error{
 				Kind:    "InvalidNodeIngressFirewall",
@@ -560,13 +567,7 @@ func checkNodeIngressFirewall(node Node, idx int, result *Errors) *Errors {
 
 func checkNodeExtraManifests(node Node, idx int, result *Errors) *Errors {
 	if len(node.ExtraManifests) > 0 {
-		var messages *multierror.Error
-
-		for k, manifest := range node.ExtraManifests {
-			if _, osErr := os.Stat(manifest); osErr != nil {
-				messages = multierror.Append(messages, fmt.Errorf("extraManifests[%d]: %q", k, osErr))
-			}
-		}
+		messages := checkExtraManifests(node.ExtraManifests)
 
 		if messages.ErrorOrNil() != nil {
 			return result.Append(&Error{
@@ -579,6 +580,56 @@ func checkNodeExtraManifests(node Node, idx int, result *Errors) *Errors {
 	}
 
 	return result
+}
+
+func checkIngressFirewall(ifCfg *IngressFirewall) *multierror.Error {
+	var messages *multierror.Error
+
+	if len(ifCfg.NetworkRules) > 0 {
+		for k, v := range ifCfg.NetworkRules {
+			if v.Name == "" {
+				messages = multierror.Append(messages, fmt.Errorf("rules[%d]: name is required", k))
+			}
+
+			if !v.PortSelector.Protocol.IsAProtocol() {
+				messages = multierror.Append(messages, fmt.Errorf("rules[%d]: %q is not a valid protocol", k, v.PortSelector.Protocol))
+			}
+
+			if len(v.PortSelector.Ports) == 0 {
+				messages = multierror.Append(messages, fmt.Errorf("rules[%d]: portSelector.ports is required", k))
+			}
+
+			if err := v.PortSelector.Ports.Validate(); err != nil {
+				messages = multierror.Append(messages, fmt.Errorf("rules[%d]: %q", k, err))
+			}
+
+			for _, rule := range v.Ingress {
+				if !rule.Subnet.IsValid() {
+					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: invalid subnet: %s", k, rule.Subnet))
+				}
+				if !rule.Except.IsZero() && !rule.Except.IsValid() {
+					messages = multierror.Append(messages, fmt.Errorf("rules[%d]: invalid except: %s", k, rule.Except))
+				}
+			}
+		}
+	}
+	if !ifCfg.DefaultAction.IsADefaultAction() {
+		messages = multierror.Append(messages, fmt.Errorf("%q is not a valid default action", ifCfg.DefaultAction))
+	}
+
+	return messages
+}
+
+func checkExtraManifests(extraManifests []string) *multierror.Error {
+	var messages *multierror.Error
+
+	for k, manifest := range extraManifests {
+		if _, osErr := os.Stat(manifest); osErr != nil {
+			messages = multierror.Append(messages, fmt.Errorf("extraManifests[%d], %q", k, osErr))
+		}
+	}
+
+	return messages
 }
 
 var hostnamePattern = sync.OnceValue(func() *regexp.Regexp {

--- a/pkg/talos/networkconfig.go
+++ b/pkg/talos/networkconfig.go
@@ -8,10 +8,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func GenerateNodeNetworkConfigBytes(node *config.Node) ([]byte, error) {
+func GenerateNetworkConfigBytes(ifCfg *config.IngressFirewall) ([]byte, error) {
 	var result [][]byte
 
-	defaultAction := GenerateNodeDefaultActionConfig(node)
+	defaultAction := GenerateNodeDefaultActionConfig(ifCfg)
 	defaultActionBytes, err := marshalYaml(defaultAction)
 	if err != nil {
 		return nil, err
@@ -19,7 +19,7 @@ func GenerateNodeNetworkConfigBytes(node *config.Node) ([]byte, error) {
 
 	result = append(result, defaultActionBytes)
 
-	rules, err := GenerateNodeRuleConfig(node)
+	rules, err := GenerateNodeRuleConfig(ifCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -36,17 +36,17 @@ func GenerateNodeNetworkConfigBytes(node *config.Node) ([]byte, error) {
 	return CombineYamlBytes(result), nil
 }
 
-func GenerateNodeDefaultActionConfig(node *config.Node) *network.DefaultActionConfigV1Alpha1 {
+func GenerateNodeDefaultActionConfig(ifCfg *config.IngressFirewall) *network.DefaultActionConfigV1Alpha1 {
 	result := network.NewDefaultActionConfigV1Alpha1()
-	result.Ingress = node.IngressFirewall.DefaultAction
+	result.Ingress = ifCfg.DefaultAction
 
 	return result
 }
 
-func GenerateNodeRuleConfig(node *config.Node) ([]*network.RuleConfigV1Alpha1, error) {
+func GenerateNodeRuleConfig(ifCfg *config.IngressFirewall) ([]*network.RuleConfigV1Alpha1, error) {
 	var result []*network.RuleConfigV1Alpha1
 
-	for _, v := range node.IngressFirewall.NetworkRules {
+	for _, v := range ifCfg.NetworkRules {
 		rule := network.NewRuleConfigV1Alpha1()
 		rule.MetaName = v.Name
 		rule.PortSelector = v.PortSelector

--- a/pkg/talos/networkconfig_test.go
+++ b/pkg/talos/networkconfig_test.go
@@ -24,8 +24,8 @@ func TestGenerateNodeDefaultActionConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	node1Result := GenerateNodeDefaultActionConfig(&m.Nodes[0])
-	node2Result := GenerateNodeDefaultActionConfig(&m.Nodes[1])
+	node1Result := GenerateNodeDefaultActionConfig(m.Nodes[0].IngressFirewall)
+	node2Result := GenerateNodeDefaultActionConfig(m.Nodes[1].IngressFirewall)
 
 	compare(node1Result.Ingress.String(), "accept", t)
 	compare(node2Result.Ingress.String(), "block", t)
@@ -82,7 +82,7 @@ func TestGenerateNodeRuleConfig(t *testing.T) {
 		{Subnet: netip.MustParsePrefix("10.10.10.3/32")},
 	}
 
-	result, err := GenerateNodeRuleConfig(&m.Nodes[0])
+	result, err := GenerateNodeRuleConfig(m.Nodes[0].IngressFirewall)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This lets you add `ingressFirewall` and `extraManifests` to all
controlplane or worker nodes too

Ref: https://github.com/budimanjojo/talhelper/issues/284
