### PR TITLE
feat(config)!: `controlPlane` and `worker` is now type of `NodeConfigs`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -58,18 +58,6 @@ nodes:
 </tr>
 
 <tr markdown="1">
-<td markdown="1">`talosImageURL`</td>
-<td markdown="1">string</td>
-<td markdown="1">**DEPRECATED, won't do anything, use `nodes[].talosImageURL` instead**.<details><summary>*Show example*</summary>
-```yaml
-talosImageURL: ghcr.io/siderolabs/installer
-```
-</details></td>
-<td markdown="1" align="center">`"ghcr.io/siderolabs/installer"`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
 <td markdown="1">`talosVersion`</td>
 <td markdown="1">string</td>
 <td markdown="1"><details><summary>Talos version to perform the installation.</summary>Image reference for each Talos release can be found on <br />[Talos GitHub release page](https://github.com)</details><details><summary>*Show example*</summary>
@@ -215,10 +203,14 @@ patches:
 
 <tr markdown="1">
 <td markdown="1">`controlPlane`</td>
-<td markdown="1">[ControlPlane](#controlplane)</td>
-<td markdown="1">Configurations targetted for controlplane nodes.</details><details><summary>*Show example*</summary>
+<td markdown="1">[NodeConfigs](#nodeconfigs)</td>
+<td markdown="1">Configurations targetted for all controlplane nodes.</details><details><summary>*Show example*</summary>
 ```yaml
 controlPlane:
+  kernelModules:
+    - name: br_netfilter
+      parameters:
+        - nf_conntrack_max=131072
   patches:
     - |-
       - op: add
@@ -238,10 +230,14 @@ controlPlane:
 
 <tr markdown="1">
 <td markdown="1">`worker`</td>
-<td markdown="1">[Worker](#worker)</td>
-<td markdown="1">Configurations targetted for worker nodes.</details><details><summary>*Show example*</summary>
+<td markdown="1">[NodeConfigs](#nodeconfigs)</td>
+<td markdown="1">Configurations targetted for all worker nodes.</details><details><summary>*Show example*</summary>
 ```yaml
 worker:
+  kernelModules:
+    - name: br_netfilter
+      parameters:
+        - nf_conntrack_max=131072
   patches:
     - |-
       - op: add
@@ -307,18 +303,6 @@ installDisk: /dev/sda
 </tr>
 
 <tr markdown="1">
-<td markdown="1">`talosImageURL`</td>
-<td markdown="1">string</td>
-<td markdown="1">Allows for supplying the node level image used to perform the installation.<details><summary>*Show example*</summary>
-```yaml
-talosImageURL: factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e
-```
-</details></td>
-<td markdown="1" align="center">`""`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
 <td markdown="1">`installDiskSelector`</td>
 <td markdown="1">[InstallDiskSelector](#installdiskselector)</td>
 <td markdown="1"><details><summary>Look up disk used for installation.</summary>Required if `installDisk` is not specified.</details><details><summary>*Show example*</summary>
@@ -331,6 +315,82 @@ installDiskSelector:
 ```
 </summary></td>
 <td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`controlPlane`</td>
+<td markdown="1">bool</td>
+<td markdown="1">Whether the node is a controlplane.<details><summary>*Show example*</summary>
+```yaml
+controlPlane: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`overridePatches`</td>
+<td markdown="1">bool</td>
+<td markdown="1"><details><summary>Whether `patches` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
+```yaml
+overridePatches: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`overrideExtraManifests`</td>
+<td markdown="1">bool</td>
+<td markdown="1"><details><summary>Whether `extraManifests` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
+```yaml
+overrideExtraManifests: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">-</td>
+<td markdown="1">[NodeConfigs](#nodeconfigs)</td>
+<td markdown="1">Node specific configurations that will override node group configurations.<details><summary>*Show example*</summary>
+```yaml
+talosImageURL: factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e
+nodeLabels:
+  rack: rack1a
+nodeTaints:
+  exampleTaint: exampletaintValue:NoSchedule
+disableSearchDomain: true
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+</table>
+
+## NodeConfigs
+
+`NodeConfigs` defines machine configurations.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`talosImageURL`</td>
+<td markdown="1">string</td>
+<td markdown="1">Allows for supplying the node level image used to perform the installation.<details><summary>*Show example*</summary>
+```yaml
+talosImageURL: factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e
+```
+</details></td>
+<td markdown="1" align="center">`""`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
@@ -367,18 +427,6 @@ ingressFirewall:
 ```
 </summary></td>
 <td markdown="1" align="center">`nil`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`controlPlane`</td>
-<td markdown="1">bool</td>
-<td markdown="1">Whether the node is a controlplane.<details><summary>*Show example*</summary>
-```yaml
-controlPlane: true
-```
-</summary></td>
-<td markdown="1" align="center">`false`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
@@ -444,19 +492,6 @@ machineFiles:
     permissions: 0o644
     path: /var/etc/tailscale/auth.env
     op: create
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`extensions`</td>
-<td markdown="1">[][InstallExtensionConfig](#installextensionconfig)</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `schematic` instead**.</summary>List of additional system extensions image to install.</details><details><summary>*Show example*</summary>
-```yaml
-extensions:
-  - image: ghcr.io/siderolabs/tailscale:1.44.0
 ```
 </summary></td>
 <td markdown="1" align="center">`[]`</td>
@@ -563,39 +598,6 @@ patches:
 ```
 </details></td>
 <td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`configPatches`</td>
-<td markdown="1">[]map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>List of RFC6902 JSON patches to be applied to the node.</details><details><summary>*Show example*</summary>
-```yaml
-configPatches:
-  - op: add
-    path: /machine/install/extraKernelArgs
-    value:
-      - console=ttyS1
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`inlinePatch`</td>
-<td markdown="1">map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>Strategic merge patches to be applied to the node.</details><details><summary>*Show example*</summary>
-```yaml
-inlinePatch:
-  machine:
-    network:
-      interfaces:
-        - interface: eth0
-          addresses: [192.168.200.11/24]
-```
-</summary></td>
-<td markdown="1" align="center">`map[]`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
@@ -798,246 +800,6 @@ ingress:
 </details></td>
 <td markdown="1" align="center">`nil`</td>
 <td markdown="1" align="center">:white_check_mark:</td>
-</tr>
-
-</table>
-
-## ControlPlane
-
-`ControlPlane` defines machine configurations for controlplane type nodes.
-
-<table markdown="1">
-<tr markdown="1">
-<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`patches`</td>
-<td markdown="1">[]string</td>
-<td markdown="1"><details><summary>Patches to be applied to all controlplane nodes.</summary>List of strings containing RFC6902 JSON patches, strategic merge patches,<br />or a file containing them.</details><details><summary>*Show example*</summary>
-```yaml
-patches:
-  - |-
-    - op: add
-      path: /machine/kubelet/extraArgs
-      value:
-        rotate-server-certificates: "true"
-  - |-
-    machine:
-      env:
-        MYENV: value
-  - "@./a-patch.yaml"
-```
-</details></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`configPatches`</td>
-<td markdown="1">[]map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>List of RFC6902 JSON patches to be applied to all controlplane nodes.</details><details><summary>*Show example*</summary>
-```yaml
-configPatches:
-  - op: add
-    path: /machine/install/extraKernelArgs
-    value:
-      - console=ttyS1
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`inlinePatch`</td>
-<td markdown="1">map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>Strategic merge patches to be applied to all controlplane nodes.</details><details><summary>*Show example*</summary>
-```yaml
-inlinePatch:
-  machine:
-    network:
-      interfaces:
-        - interface: eth0
-          addresses: [192.168.200.11/24]
-```
-</summary></td>
-<td markdown="1" align="center">`map[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`schematic`</td>
-<td markdown="1">[Schematic](#schematic)</td>
-<td markdown="1">Configure Talos image customization to be applied to all controlplane nodes<details><summary>*Show example*</summary>
-```yaml
-schematic:
-  customization:
-    extraKernelArgs:
-      - net.ifnames=0
-    systemExtensions:
-      officialExtensions:
-        - siderolabs/intel-ucode
-```
-</summary></td>
-<td markdown="1" align="center">`nil`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`ingressFirewall`</td>
-<td markdown="1">[IngressFirewall](#ingressfirewall)</td>
-<td markdown="1">Firewall specification for all controlplane nodes.<details><summary>*Show example*</summary>
-```yaml
-ingressFirewall:
-  defaultAction: block
-  rules:
-    - name: kubelet-ingress
-      portSelector:
-        ports:
-          - 10250
-        protocol: tcp
-      ingress:
-        - subnet: 172.20.0.0/24
-          except: 172.20.0.1/32
-```
-</summary></td>
-<td markdown="1" align="center">`nil`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`extraManifests`</td>
-<td markdown="1">[]string</td>
-<td markdown="1">List of manifest files to be added to all controlplane nodes.<details><summary>*Show example*</summary>
-```yaml
-extraManifests:
-  - etcd-firewall.yaml
-  - kubelet-firewall.yaml
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-</table>
-
-## Worker
-
-`Worker` defines machine configurations for worker type nodes.
-
-<table markdown="1">
-<tr markdown="1">
-<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`patches`</td>
-<td markdown="1">[]string</td>
-<td markdown="1"><details><summary>Patches to be applied to all worker nodes.</summary>List of strings containing RFC6902 JSON patches, strategic merge patches,<br />or a file containing them.</details><details><summary>*Show example*</summary>
-```yaml
-patches:
-  - |-
-    - op: add
-      path: /machine/kubelet/extraArgs
-      value:
-        rotate-server-certificates: "true"
-  - |-
-    machine:
-      env:
-        MYENV: value
-  - "@./a-patch.yaml"
-```
-</details></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`configPatches`</td>
-<td markdown="1">[]map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>List of RFC6902 JSON patches to be applied to all worker nodes.</details><details><summary>*Show example*</summary>
-```yaml
-configPatches:
-  - op: add
-    path: /machine/install/extraKernelArgs
-    value:
-      - console=ttyS1
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`inlinePatch`</td>
-<td markdown="1">map[string]interface{}</td>
-<td markdown="1"><details><summary>**DEPRECATED, use `patches` instead**.</summary>Strategic merge patches to be applied to all worker nodes.</details><details><summary>*Show example*</summary>
-```yaml
-inlinePatch:
-  machine:
-    network:
-      interfaces:
-        - interface: eth0
-          addresses: [192.168.200.11/24]
-```
-</summary></td>
-<td markdown="1" align="center">`map[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`schematic`</td>
-<td markdown="1">[Schematic](#schematic)</td>
-<td markdown="1">Configure Talos image customization to be applied to all worker nodes<details><summary>*Show example*</summary>
-```yaml
-schematic:
-  customization:
-    extraKernelArgs:
-      - net.ifnames=0
-    systemExtensions:
-      officialExtensions:
-        - siderolabs/intel-ucode
-```
-</summary></td>
-<td markdown="1" align="center">`nil`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`ingressFirewall`</td>
-<td markdown="1">[IngressFirewall](#ingressfirewall)</td>
-<td markdown="1">Firewall specification for all worker nodes.<details><summary>*Show example*</summary>
-```yaml
-ingressFirewall:
-  defaultAction: block
-  rules:
-    - name: kubelet-ingress
-      portSelector:
-        ports:
-          - 10250
-        protocol: tcp
-      ingress:
-        - subnet: 172.20.0.0/24
-          except: 172.20.0.1/32
-```
-</summary></td>
-<td markdown="1" align="center">`nil`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
-</tr>
-
-<tr markdown="1">
-<td markdown="1">`extraManifests`</td>
-<td markdown="1">[]string</td>
-<td markdown="1">List of manifest files to be added to all worker nodes.<details><summary>*Show example*</summary>
-```yaml
-extraManifests:
-  - etcd-firewall.yaml
-  - kubelet-firewall.yaml
-```
-</summary></td>
-<td markdown="1" align="center">`[]`</td>
-<td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
 </table>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 
 type TalhelperConfig struct {
 	ClusterName                    string              `yaml:"clusterName" jsonschema:"required,description=Name of the cluster"`
-	TalosImageURL                  string              `yaml:"talosImageURL" jsonschema:"default=ghcr.io/siderolabs/installer,description=DEPRECATED: will not do anything, use \"nodes[].talosImageURL\" instead"`
 	TalosVersion                   string              `yaml:"talosVersion,omitempty" jsonschema:"example=v1.5.4,description=Talos version to perform installation"`
 	KubernetesVersion              string              `yaml:"kubernetesVersion,omitempty" jsonschema:"example=v1.27.0,description=Kubernetes version to use"`
 	Endpoint                       string              `yaml:"endpoint" jsonschema:"required,example=https://192.168.200.10:6443,description=Cluster's controlplane endpoint"`
@@ -24,51 +23,36 @@ type TalhelperConfig struct {
 	Patches                        []string            `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all nodes"`
 	Nodes                          []Node              `yaml:"nodes" jsonschema:"required,description=List of configurations for Node"`
 	ImageFactory                   ImageFactory        `yaml:"imageFactory,omitempty" jsonschema:"Configuration for image factory"`
-	ControlPlane                   controlPlane        `yaml:"controlPlane,omitempty" jsonschema:"description=Configurations targetted for controlplane nodes"`
-	Worker                         worker              `yaml:"worker,omitempty" jsonschema:"description=Configurations targetted for worker nodes"`
+	ControlPlane                   NodeConfigs         `yaml:"controlPlane,omitempty" jsonschema:"description=Configurations targetted for all controlplane nodes"`
+	Worker                         NodeConfigs         `yaml:"worker,omitempty" jsonschema:"description=Configurations targetted for all worker nodes"`
 }
 
 type Node struct {
-	Hostname            string                            `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress           string                            `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached"`
-	ControlPlane        bool                              `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	NodeLabels          map[string]string                 `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node"`
-	NodeTaints          map[string]string                 `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
-	InstallDisk         string                            `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector *v1alpha1.InstallDiskSelector     `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	MachineDisks        []*v1alpha1.MachineDisk           `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
-	MachineFiles        []*v1alpha1.MachineFile           `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
-	Extensions          []v1alpha1.InstallExtensionConfig `yaml:"extensions,omitempty" jsonschema:"description=DEPRECATED: use \"schematic\" instead"`
-	DisableSearchDomain bool                              `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
-	KernelModules       []*v1alpha1.KernelModuleConfig    `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
-	Nameservers         []string                          `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
-	NetworkInterfaces   []*v1alpha1.Device                `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
-	ExtraManifests      []string                          `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
-	ConfigPatches       []map[string]interface{}          `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	InlinePatch         map[string]interface{}            `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	Patches             []string                          `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
-	TalosImageURL       string                            `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
-	Schematic           *schematic.Schematic              `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
-	MachineSpec         MachineSpec                       `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
-	IngressFirewall     *IngressFirewall                  `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
+	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached"`
+	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
-type controlPlane struct {
-	ConfigPatches   []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	InlinePatch     map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	Patches         []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all controlplane nodes"`
-	Schematic       *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all controlplane nodes"`
-	IngressFirewall *IngressFirewall         `yaml:"ingressFirewall,omitempty" jsonschema:"description=Firewall specification for all controlplane nodes"`
-	ExtraManifests  []string                 `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to all controlplane nodes"`
-}
-
-type worker struct {
-	ConfigPatches   []map[string]interface{} `yaml:"configPatches,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	InlinePatch     map[string]interface{}   `yaml:"inlinePatch,omitempty" jsonschema:"description=DEPRECATED: use \"patches\" instead"`
-	Patches         []string                 `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all worker nodes"`
-	Schematic       *schematic.Schematic     `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be applied to all worker nodes"`
-	IngressFirewall *IngressFirewall         `yaml:"ingressFirewall,omitempty" jsonschema:"description=Firewall specification for all worker nodes"`
-	ExtraManifests  []string                 `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to all worker nodes"`
+type NodeConfigs struct {
+	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node"`
+	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
+	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
+	MachineFiles        []*v1alpha1.MachineFile        `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
+	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
+	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
+	NetworkInterfaces   []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
+	ExtraManifests      []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
+	Patches             []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
+	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
+	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
+	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
+	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 }
 
 type ImageFactory struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -71,15 +71,6 @@ func (c *TalhelperConfig) GetClusterSvcNets() []string {
 	return c.ClusterSvcNets
 }
 
-// GetInstallerURL returns installer URL string.
-func (c *TalhelperConfig) GetInstallerURL() string {
-	if c.TalosImageURL != "" {
-		return c.TalosImageURL + ":" + c.GetTalosVersion()
-	}
-
-	return "ghcr.io/siderolabs/installer:" + c.GetTalosVersion()
-}
-
 // GetImageFactory returns default `imageFactory` if not specified.
 func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
 	result := &ImageFactory{

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -35,13 +35,9 @@ func LoadAndValidateFromFile(filePath string, envPaths []string) (*TalhelperConf
 	for k, node := range cfg.Nodes {
 		switch node.ControlPlane {
 		case true:
-			if cfg.ControlPlane.Schematic != nil && node.Schematic == nil {
-				cfg.Nodes[k].Schematic = cfg.ControlPlane.Schematic
-			}
+			cfg.Nodes[k].OverrideGlobalCfg(cfg.ControlPlane)
 		case false:
-			if cfg.Worker.Schematic != nil && node.Schematic == nil {
-				cfg.Nodes[k].Schematic = cfg.Worker.Schematic
-			}
+			cfg.Nodes[k].OverrideGlobalCfg(cfg.Worker)
 		}
 	}
 

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -19,12 +19,15 @@ func TestLoadAndValidateFromFile(t *testing.T) {
 		IPAddress:    "192.168.200.10",
 		ControlPlane: true,
 		InstallDisk:  "/dev/sda",
-		Schematic: &schematic.Schematic{
-			Customization: schematic.Customization{
-				SystemExtensions: schematic.SystemExtensions{
-					OfficialExtensions: []string{"siderolabs/tailscale"},
+		NodeConfigs: NodeConfigs{
+			Schematic: &schematic.Schematic{
+				Customization: schematic.Customization{
+					SystemExtensions: schematic.SystemExtensions{
+						OfficialExtensions: []string{"siderolabs/tailscale"},
+					},
 				},
 			},
+			DisableSearchDomain: true,
 		},
 	}
 	expectedNode1 := Node{
@@ -32,9 +35,11 @@ func TestLoadAndValidateFromFile(t *testing.T) {
 		IPAddress:    "192.168.200.11",
 		ControlPlane: false,
 		InstallDisk:  "/dev/sda",
-		Schematic: &schematic.Schematic{
-			Customization: schematic.Customization{
-				ExtraKernelArgs: []string{"net.ifnames=0"},
+		NodeConfigs: NodeConfigs{
+			Schematic: &schematic.Schematic{
+				Customization: schematic.Customization{
+					ExtraKernelArgs: []string{"net.ifnames=0"},
+				},
 			},
 		},
 	}

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"reflect"
+)
+
+func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
+	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests)
+
+	return node
+}
+
+func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest bool) NodeConfigs {
+	if len(src.Patches) > 0 && !overridePatches {
+		patch.Patches = append(patch.Patches, src.Patches...)
+	}
+	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {
+		patch.ExtraManifests = append(patch.ExtraManifests, src.ExtraManifests...)
+	}
+
+	patchValue := reflect.ValueOf(patch)
+	srcValue := reflect.ValueOf(src)
+
+	result := reflect.New(patchValue.Type()).Elem()
+
+	for i := 0; i < patchValue.NumField(); i++ {
+		patchField := patchValue.Field(i)
+		srcField := srcValue.Field(i)
+
+		if !patchField.IsZero() {
+			result.Field(i).Set(patchField)
+		} else {
+			result.Field(i).Set(srcField)
+		}
+	}
+
+	return result.Interface().(NodeConfigs)
+}

--- a/pkg/config/nodeconfigs_test.go
+++ b/pkg/config/nodeconfigs_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/siderolabs/image-factory/pkg/schematic"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+)
+
+func TestOverrideNodeConfigs(t *testing.T) {
+	globalCfg := NodeConfigs{
+		NodeLabels: map[string]string{
+			"testkey": "testValue",
+		},
+		Schematic: &schematic.Schematic{
+			Customization: schematic.Customization{
+				ExtraKernelArgs: []string{"enable=1"},
+			},
+		},
+	}
+
+	node := Node{
+		Hostname:     "test-host",
+		IPAddress:    "123.456.789.1",
+		InstallDisk:  "/dev/test",
+		ControlPlane: true,
+		NodeConfigs: NodeConfigs{
+			NodeLabels: map[string]string{
+				"testkey": "overwritten",
+			},
+			MachineDisks: []*v1alpha1.MachineDisk{
+				{
+					DeviceName: "/dev/sda",
+					DiskPartitions: []*v1alpha1.DiskPartition{
+						{
+							DiskSize:       v1alpha1.DiskSize(1),
+							DiskMountPoint: "/hello",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedNode := Node{
+		Hostname:     "test-host",
+		IPAddress:    "123.456.789.1",
+		InstallDisk:  "/dev/test",
+		ControlPlane: true,
+		NodeConfigs: NodeConfigs{
+			NodeLabels: map[string]string{
+				"testkey": "overwritten",
+			},
+			MachineDisks: []*v1alpha1.MachineDisk{
+				{
+					DeviceName: "/dev/sda",
+					DiskPartitions: []*v1alpha1.DiskPartition{
+						{
+							DiskSize:       v1alpha1.DiskSize(1),
+							DiskMountPoint: "/hello",
+						},
+					},
+				},
+			},
+			Schematic: &schematic.Schematic{
+				Customization: schematic.Customization{
+					ExtraKernelArgs: []string{"enable=1"},
+				},
+			},
+		},
+	}
+
+	node.OverrideGlobalCfg(globalCfg)
+
+	if !reflect.DeepEqual(node, expectedNode) {
+		t.Errorf("got:\n%v\nwant:\n%v", node, expectedNode)
+	}
+}

--- a/pkg/config/testdata/talconfig.yaml
+++ b/pkg/config/testdata/talconfig.yaml
@@ -16,6 +16,7 @@ nodes:
     installDisk: /dev/sda
     controlPlane: false
 controlPlane:
+  disableSearchDomain: true
   schematic:
     customization:
       systemExtensions:

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -44,8 +44,6 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 	checkDomain(c, &result)
 	checkClusterNets(c, &result)
 	checkCNIConfig(c, &result)
-	checkControlPlane(c, &result)
-	checkWorker(c, &result)
 	for k, node := range c.Nodes {
 		checkNodeRequiredCfg(node, k, &result)
 		checkNodeIPAddress(node, k, &result)
@@ -54,11 +52,9 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeTaints(node, k, &result)
 		checkNodeMachineDisks(node, k, &result)
 		checkNodeMachineFiles(node, k, &result)
-		checkNodeExtensions(node, k, &result, &warns)
 		checkNodeSchematic(node, k, c.GetTalosVersion(), &result)
 		checkNodeNameServers(node, k, &result)
 		checkNodeNetworkInterfaces(node, k, &result)
-		checkNodeConfigPatches(node, k, &result)
 		checkNodeIngressFirewall(node, k, &result)
 		checkNodeExtraManifests(node, k, &result)
 	}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -33,8 +33,6 @@ nodes:
     ipAddress: 1.2.3.4.5
     installDisk: /dev/sda
     disableSearchDomain: true
-    extensions:
-      - image: hehe
     nameservers:
       - 8.8.8.8
     networkInterfaces:
@@ -44,9 +42,6 @@ nodes:
         routes:
           - network: 0.0.0.0/0
             gateway: 1.2.3.4.5.6
-    configPatches:
-      - op: del
-        path: /cluster
     ingressFirewall:
       defaultAction: block
       rules:
@@ -73,52 +68,39 @@ nodes:
      - test.yaml
 `)
 
-	errs, warns, err := ValidateFromByte(data)
+	errs, _, err := ValidateFromByte(data)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expectedErrors := map[string]bool{
-		"clusterName":                  false,
-		"talosVersion":                 true,
-		"kubernetesVersion":            true,
-		"endpoint":                     true,
-		"cniConfig":                    true,
-		"clusterPodNets":               false,
-		"clusterSvcNets":               true,
-		"controlPlane.ingressFirewall": true,
-		"worker.extraManifests":        true,
-		"nodes[0].hostname":            false,
-		"nodes[0].ipAddress":           false,
-		"nodes[0].controlPlane":        false,
-		"nodes[0].installDisk":         false,
-		"nodes[0].nameservers":         false,
-		"nodes[0].ingressFirewall":     false,
-		"nodes[0].networkInterfaces":   true,
-		"nodes[0].configPatches":       true,
-		"nodes[1].hostname":            true,
-		"nodes[1].ipAddress":           true,
-		"nodes[1].installDisk":         true,
-		"nodes[1].nodeLabels":          true,
-		"nodes[1].nodeTaints":          true,
-		"nodes[1].machineFiles":        true,
-		"nodes[1].schematic":           true,
-		"nodes[1].extraManifests":      true,
-	}
-
-	expectedWarnings := map[string]bool{
-		"nodes[0].extensions": true,
+		"clusterName":                false,
+		"talosVersion":               true,
+		"kubernetesVersion":          true,
+		"endpoint":                   true,
+		"cniConfig":                  true,
+		"clusterPodNets":             false,
+		"clusterSvcNets":             true,
+		"nodes[0].hostname":          false,
+		"nodes[0].ipAddress":         false,
+		"nodes[0].controlPlane":      false,
+		"nodes[0].installDisk":       false,
+		"nodes[0].nameservers":       false,
+		"nodes[0].ingressFirewall":   false,
+		"nodes[0].networkInterfaces": true,
+		"nodes[1].hostname":          true,
+		"nodes[1].ipAddress":         true,
+		"nodes[1].installDisk":       true,
+		"nodes[1].nodeLabels":        true,
+		"nodes[1].nodeTaints":        true,
+		"nodes[1].machineFiles":      true,
+		"nodes[1].schematic":         true,
+		"nodes[1].extraManifests":    true,
 	}
 
 	for k, v := range expectedErrors {
 		if errs.HasField(k) != v {
 			t.Errorf("%s: got %t, want %t", k, errs.HasField(k), v)
-		}
-	}
-
-	for k, v := range expectedWarnings {
-		if warns.HasField(k) != v {
-			t.Errorf("%s: got %t, want %t", k, warns.HasField(k), v)
 		}
 	}
 }

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -35,50 +35,8 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 			return err
 		}
 
-		if node.InlinePatch != nil {
-			cfg, err = patcher.YAMLInlinePatcher(node.InlinePatch, cfg)
-			if err != nil {
-				return err
-			}
-		}
-
-		if len(node.ConfigPatches) != 0 {
-			cfg, err = patcher.YAMLPatcher(node.ConfigPatches, cfg)
-			if err != nil {
-				return err
-			}
-		}
-
 		if len(node.Patches) != 0 {
 			cfg, err = patcher.PatchesPatcher(node.Patches, cfg)
-			if err != nil {
-				return err
-			}
-		}
-
-		if node.ControlPlane {
-			cfg, err = patcher.YAMLInlinePatcher(c.ControlPlane.InlinePatch, cfg)
-			if err != nil {
-				return err
-			}
-			cfg, err = patcher.YAMLPatcher(c.ControlPlane.ConfigPatches, cfg)
-			if err != nil {
-				return err
-			}
-			cfg, err = patcher.PatchesPatcher(c.ControlPlane.Patches, cfg)
-			if err != nil {
-				return err
-			}
-		} else {
-			cfg, err = patcher.YAMLInlinePatcher(c.Worker.InlinePatch, cfg)
-			if err != nil {
-				return err
-			}
-			cfg, err = patcher.YAMLPatcher(c.Worker.ConfigPatches, cfg)
-			if err != nil {
-				return err
-			}
-			cfg, err = patcher.PatchesPatcher(c.Worker.Patches, cfg)
 			if err != nil {
 				return err
 			}
@@ -115,38 +73,6 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 				return err
 			}
 			cfg = append(cfg, content...)
-		}
-
-		if node.ControlPlane {
-			if c.ControlPlane.IngressFirewall != nil {
-				nc, err := talos.GenerateNetworkConfigBytes(c.ControlPlane.IngressFirewall)
-				if err != nil {
-					return err
-				}
-				cfg = append(cfg, nc...)
-			}
-			if len(c.ControlPlane.ExtraManifests) > 0 {
-				content, err := combineExtraManifests(c.ControlPlane.ExtraManifests)
-				if err != nil {
-					return err
-				}
-				cfg = append(cfg, content...)
-			}
-		} else {
-			if c.Worker.IngressFirewall != nil {
-				nc, err := talos.GenerateNetworkConfigBytes(c.Worker.IngressFirewall)
-				if err != nil {
-					return err
-				}
-				cfg = append(cfg, nc...)
-			}
-			if len(c.Worker.ExtraManifests) > 0 {
-				content, err := combineExtraManifests(c.Worker.ExtraManifests)
-				if err != nil {
-					return err
-				}
-				cfg = append(cfg, content...)
-			}
 		}
 
 		if !dryRun {

--- a/pkg/talos/input.go
+++ b/pkg/talos/input.go
@@ -67,7 +67,7 @@ func parseOptions(c *config.TalhelperConfig, versionContract *tconfig.VersionCon
 
 	opts = append(opts, generate.WithVersionContract(versionContract))
 	opts = append(opts, generate.WithSecretsBundle(sb))
-	opts = append(opts, generate.WithInstallImage(c.GetInstallerURL()))
+	opts = append(opts, generate.WithInstallImage("ghcr.io/siderolabs/installer:"+c.GetTalosVersion()))
 
 	if c.AllowSchedulingOnMasters || c.AllowSchedulingOnControlPlanes {
 		opts = append(opts, generate.WithAllowSchedulingOnControlPlanes(true))

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -92,10 +92,6 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineNodeTaints = node.NodeTaints
 	}
 
-	if len(node.Extensions) > 0 {
-		cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtensions = node.Extensions
-	}
-
 	if len(node.MachineFiles) > 0 {
 		cfg.RawV1Alpha1().MachineConfig.MachineFiles = node.MachineFiles
 	}

--- a/pkg/talos/nodeconfig_test.go
+++ b/pkg/talos/nodeconfig_test.go
@@ -95,11 +95,6 @@ nodes:
 	expectedNode1Hostname := "node1"
 	expectedNode1InstallDisk := "/dev/sda"
 	expectedNode1DisableSearchDomain := true
-	expectedNode1Extensions := []v1alpha1.InstallExtensionConfig{
-		{
-			ExtensionImage: "ghcr.io/siderolabs/tailscale:1.44.0",
-		},
-	}
 	expectedNode1MachineFiles := []*v1alpha1.MachineFile{
 		{
 			FileContent:     "TS_AUTHKEY=123456",
@@ -163,7 +158,6 @@ nodes:
 	compare(cpCfg.MachineNetwork.Hostname(), expectedNode1Hostname, t)
 	compare(cpCfg.MachineInstall.InstallDisk, expectedNode1InstallDisk, t)
 	compare(cpCfg.MachineNetwork.DisableSearchDomain(), expectedNode1DisableSearchDomain, t)
-	compare(cpCfg.MachineInstall.InstallExtensions, expectedNode1Extensions, t)
 	compare(cpCfg.MachineFiles, expectedNode1MachineFiles, t)
 	compare(cpCfg.MachineNetwork.NetworkInterfaces, expectedNode1NetworkInterfaces, t)
 	compare(cpCfg.MachineKernel, expectedNode1KernelModules, t)


### PR DESCRIPTION
This will allow all `NodeConfigs` fields to be applicable on node group
(`controlPlane` or `worker` depending on node type) or per node level.

The config will be "merged" with everything defined on per node level
take precedence, except for `patches` and `extraManifests` to keep the
behavior before this commit. Patches and extaManifests defined on both
node and node group level will be appended instead.

There are 2 new node options to change the behavior of `patches` and
`extraManifests` when defined at both the node and node group level.
Which are: `overridePatches` and `overrideExtraManifests`. By setting
them to `true` will make the `patches` and `extraManifests` defined in
node level to override the ones defined in node group level.

The config validation is now done after the "merging" is done for each
node. So, i.e when you define `schematic` incorrectly in `controlPlane`
struct, you might see the validation says you have incorrect
`nodes[0].schematic` instead assuming `nodes[0]` is a controlPlane node.

BREAKING CHANGE: This commit also remove all the deprecated fields which
are:
* `talosImageURL`
* all `inlinePatch`
* all `configPatches`
* `nodes[].extensions`
