### PR TITLE
Support generating single file for all nodes

### DIFF
--- a/cmd/genurl_iso.go
+++ b/cmd/genurl_iso.go
@@ -31,7 +31,7 @@ var genurlISOCmd = &cobra.Command{
 
 			var urls []string
 			for _, node := range cfg.Nodes {
-				if genurlNode != "" && node.IPAddress != genurlNode && node.Hostname != genurlNode {
+				if genurlNode != "" && !node.ContainsIP(genurlNode) && node.Hostname != genurlNode {
 					continue
 				}
 
@@ -40,7 +40,7 @@ var genurlISOCmd = &cobra.Command{
 					schema = node.Schematic
 				}
 
-				if node.IPAddress == genurlNode || node.Hostname == genurlNode {
+				if node.ContainsIP(genurlNode) || node.Hostname == genurlNode {
 					url, err := talos.GetISOURL(schema, cfg.GetImageFactory(), node.GetMachineSpec(), cfg.GetTalosVersion(), genurlOfflineMode)
 					if err != nil {
 						log.Fatalf("Failed to generate ISO url for %s, %v", node.Hostname, err)

--- a/docs/docs/guides.md
+++ b/docs/docs/guides.md
@@ -260,6 +260,29 @@ There are some other `gencommand` commands that you can use like `upgrade`, `upg
 
 For more information about the available `gencommand` commands and flags you can use, head over to the [documentation](./reference/cli.md#talhelper-gencommand).
 
+## Generate single config file for multiple nodes
+
+Thanks to the idea from [onedr0p](https://github.com/onedr0p), you can generate a single config file for multiple nodes.
+This is useful if you have identical hardware for all your nodes and you use DHCP server to manage your node's IP address and hostname.
+The idea is to set `nodes[].ignoreHostname` to `true` and set `nodes[].ipAddress` to multiple IP addresses separated by comma:
+
+```yaml
+---
+clusterName: my-cluster
+nodes:
+  - hostname: controller
+    ipAddress: 192.168.10.11, 192.168.10.12, 192.168.10.13
+    controlPlane: true
+    ignoreHostname: true
+  - hostname: worker
+    ipAddress: 192.168.10.14, 192.168.10.15, 192.168.10.16
+    controlPlane: false
+    ignoreHostname: true
+```
+
+This will generate `my-cluster-controller.yaml` and `my-cluster-worker.yaml` that you can apply with `talosctl apply-config` command.
+You can also use `talhelper gencommand <command> -n <hostname/IP>` to generate the `talosctl` commands for your nodes.
+
 ## Selfhosted Image Factory
 
 By default, the generated manifests will use the official [image-factory](https://factory.talos.dev) to pull the installer image.

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -331,6 +331,18 @@ controlPlane: true
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`ignoreHostname`</td>
+<td markdown="1">bool</td>
+<td markdown="1">Whether to set `machine.network.hostname` to the generated config file.<details><summary>*Show example*</summary>
+```yaml
+ignoreHostname: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`overridePatches`</td>
 <td markdown="1">bool</td>
 <td markdown="1"><details><summary>Whether `patches` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -281,7 +281,7 @@ hostname: kmaster1
 <tr markdown="1">
 <td markdown="1">`ipAddress`</td>
 <td markdown="1">string</td>
-<td markdown="1"><details><summary>IP address where the node can be reached.</summary>Needed for endpoint and node address inside `talosconfig`.</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>IP address where the node can be reached, can be IP or comma separated list of IPs.</summary>Needed for endpoint and node address inside `talosconfig`.</details><details><summary>*Show example*</summary>
 ```yaml
 ipAddress: 192.168.200.11
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type Node struct {
 	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
 	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
 	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
 	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
 	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
 	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,7 +29,7 @@ type TalhelperConfig struct {
 
 type Node struct {
 	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached"`
+	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
 	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
 	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
 	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/netip"
+	"slices"
 	"strings"
 	"tsehelper/pkg/versiontags"
 
@@ -110,6 +111,21 @@ func (n *Node) GetMachineSpec() *MachineSpec {
 	result.Secureboot = n.MachineSpec.Secureboot
 	result.UseUKI = n.MachineSpec.UseUKI
 	return result
+}
+
+// GetIPAddresses returns list of IPaddresses
+func (n *Node) GetIPAddresses() []string {
+	var result []string
+	ips := strings.Split(n.IPAddress, ",")
+	for _, ip := range ips {
+		result = append(result, strings.TrimSpace(ip))
+	}
+	return result
+}
+
+// ContainsIP returns true if `n.IPAddress` contains `ip`
+func (n *Node) ContainsIP(ip string) bool {
+	return slices.Contains(n.GetIPAddresses(), ip)
 }
 
 // endpointisIPv6 returns true if string is IPv6 address.

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -244,11 +244,18 @@ func checkNodeRequiredCfg(node Node, idx int, result *Errors) *Errors {
 
 func checkNodeIPAddress(node Node, idx int, result *Errors) *Errors {
 	if node.IPAddress != "" {
-		if !isDomainOrIP(node.IPAddress) {
+		var messages *multierror.Error
+		for _, ip := range node.GetIPAddresses() {
+			if !isDomainOrIP(ip) {
+				messages = multierror.Append(messages, fmt.Errorf("%q is not a valid domain or IP address", ip))
+			}
+		}
+
+		if messages.ErrorOrNil() != nil {
 			return result.Append(&Error{
 				Kind:    "InvalidNodeIPAddress",
 				Field:   getNodeFieldYamlTag(node, idx, "IPAddress"),
-				Message: formatError(multierror.Append(fmt.Errorf("%q is not a valid domain or IP address", node.IPAddress))),
+				Message: formatError(messages),
 			})
 		}
 	}

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -53,7 +53,9 @@ func GenerateNodeConfig(node *config.Node, input *generate.Input, iFactory *conf
 }
 
 func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provider {
-	cfg.RawV1Alpha1().MachineConfig.MachineNetwork.NetworkHostname = node.Hostname
+	if !node.IgnoreHostname {
+		cfg.RawV1Alpha1().MachineConfig.MachineNetwork.NetworkHostname = node.Hostname
+	}
 
 	if len(node.Nameservers) > 0 {
 		cfg.RawV1Alpha1().MachineConfig.MachineNetwork.NameServers = node.Nameservers

--- a/pkg/talos/talosconfig.go
+++ b/pkg/talos/talosconfig.go
@@ -9,7 +9,7 @@ func GenerateClientConfigBytes(c *config.TalhelperConfig, input *generate.Input)
 	var endpoints []string
 	for _, node := range c.Nodes {
 		if node.ControlPlane {
-			endpoints = append(endpoints, node.IPAddress)
+			endpoints = append(endpoints, node.GetIPAddresses()...)
 		}
 	}
 	input.Options.EndpointList = endpoints


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/344

This allows the generated configs to be applicable by many nodes, i.e you have similar hardware for all your nodes and let your DHCP server to handle the IP addresses and hostname for you.
