### PR TITLE
feat(config): global patches should be applied first

### DIFF
--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -12,7 +12,9 @@ func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
 
 func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
-		patch.Patches = append(patch.Patches, src.Patches...)
+		// global patches should get applied first
+		// https://github.com/budimanjojo/talhelper/issues/388
+		patch.Patches = append(src.Patches, patch.Patches...)
 	}
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {
 		patch.ExtraManifests = append(patch.ExtraManifests, src.ExtraManifests...)


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/388

Before this, the `patches` in `nodes[]` will get applied first, then the `patches` in `controlPlane` or `worker`.

This resulted in a scenario like this will not be possible:

```yaml
nodes:
  - hostname: master
    controlPlane: true
    overridePatches: false
    patches:
      - |-
        - op: add
          path: /machine/kubelet/extraMounts/-
          value:
            destination: /var/mnt/tank
            type: bind
            options:
              - bind
controlPlane:
  patches:
    - |-
      - op: add
        path: /machine/kubelet/extraMounts
        value:
          - destination: /var/lib/longhorn
            options:
              - bind
```

Your goal is to have `/machine/kubelet/extraMounts` of `master` node to have 2 items, while the other `controlPlane` nodes to have 1 item.
After this patch, this should now work fine.
