### PR TITLE
WIP: Support externally defined machine files.

### DIFF
--- a/example/moreMachineFiles.yaml
+++ b/example/moreMachineFiles.yaml
@@ -1,0 +1,9 @@
+- content: |
+    ANOTHER_TS_AUTHKEY=123456
+  permissions: 0o644
+  path: /var/etc/tailscale/another_auth.env
+  op: create
+- content: "@./tsauth.env"
+  permissions: 0o644
+  path: /var/etc/tailscale2/another_auth.env
+  op: create

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -61,6 +61,7 @@ nodes:
         permissions: 0o644
         path: /var/etc/tailscale2/auth.env
         op: create
+      - "@./moreMachineFiles.yaml"
     installDiskSelector:
       size: 4GB
       model: WDC*

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,10 +40,11 @@ type Node struct {
 }
 
 type NodeConfigs struct {
-	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node"`
-	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
-	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
-	MachineFiles        []*v1alpha1.MachineFile        `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	NodeLabels          map[string]string       `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node"`
+	NodeTaints          map[string]string       `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
+	MachineDisks        []*v1alpha1.MachineDisk `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
+	MachineFileConfigs  []MachineFile           `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	MachineFiles        []*v1alpha1.MachineFile
 	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
 	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
 	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
@@ -55,6 +56,8 @@ type NodeConfigs struct {
 	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
 	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 }
+
+type MachineFile interface{}
 
 type ImageFactory struct {
 	RegistryURL       string `yaml:"registryURL,omitempty" jsonschema:"default=factory.talos.dev,description=Registry url or the image"`


### PR DESCRIPTION
This is a first attempt to support externally defined machine files as well.

What the code does is:

* reads machineFiles key from config into machineFileConfigs
for all items in this slice:
* figures out if this is a proper machineFile type (a map) or a pointer to an external file (string starts with "@")
* if it's a map, read it and add it to the actual machineFiles key in the struct
* if it's a string, find the file, and add them to a list of additionalMachineFiles that still need to be read.

for all items in the list of additionalMachineFiles
* check if it's a machineFile type (a map), read it and add it to the actual machineFiles key


Things that need to be checked:

* [ ] Tests are failing
* [ ] Figure out what the difference between LoadAndValidateFromFile and NewFromByte/NewFromFile is and why LoadAndValidateFromFile is not used in the tests/elsewhere.