### PR TITLE
feat(docker): Add ability to inject build flags to the `go build` command

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -54,6 +54,8 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            VERSION=${{ github.ref_name }}
 
       - name: Export digest
         id: export

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-# Additional build flags passed to the `go build` command
-ARG BUILD_FLAGS
-
+ARG VERSION
 
 ## ================================================================================================
 ## Builder Stage -> creating the binary
 ## ================================================================================================
 FROM golang:1.22.3-alpine3.18 as builder
-ARG BUILD_FLAGS
+ARG VERSION
+
 WORKDIR /build
 COPY . .
-RUN go build ${BUILD_FLAGS} -o /usr/local/bin/talhelper
-
+RUN go build -ldflags="-s -w -X github.com/budimanjojo/talhelper/cmd.version=${VERSION}" -o /usr/local/bin/talhelper
 
 
 ## ================================================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
+# Additional build flags passed to the `go build` command
+ARG BUILD_FLAGS
+
+
+## ================================================================================================
+## Builder Stage -> creating the binary
+## ================================================================================================
 FROM golang:1.22.3-alpine3.18 as builder
+ARG BUILD_FLAGS
 WORKDIR /build
 COPY . .
-RUN go build -o /usr/local/bin/talhelper
+RUN go build ${BUILD_FLAGS} -o /usr/local/bin/talhelper
 
+
+
+## ================================================================================================
+## Serving/Production Stage
+## ================================================================================================
 FROM scratch
 COPY --from=builder /usr/local/bin/talhelper /usr/local/bin/talhelper
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
With this build arg we can inject extra flags to the `go build` command so that we can set up the `--version` flag for the binary distributed via docker.

Fixes #473 