### PR TITLE
feat: bump the go module to `v3`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X github.com/budimanjojo/talhelper/cmd.version={{.Version}}
+      - -s -w -X github.com/budimanjojo/talhelper/v3/cmd.version={{.Version}}
   - id: talhelper-windows-amd64
     env:
       - CGO_ENABLED=0
@@ -19,7 +19,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/budimanjojo/talhelper/cmd.version={{.Version}}
+      - -s -w -X github.com/budimanjojo/talhelper/v3/cmd.version={{.Version}}
 archives:
   - name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
 checksum:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION
 
 WORKDIR /build
 COPY . .
-RUN go build -ldflags="-s -w -X github.com/budimanjojo/talhelper/cmd.version=${VERSION}" -o /usr/local/bin/talhelper
+RUN go build -ldflags="-s -w -X github.com/budimanjojo/talhelper/v3/cmd.version=${VERSION}" -o /usr/local/bin/talhelper
 
 
 ## ================================================================================================

--- a/cmd/gencommand_apply.go
+++ b/cmd/gencommand_apply.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandApplyCmd = &cobra.Command{

--- a/cmd/gencommand_bootstrap.go
+++ b/cmd/gencommand_bootstrap.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandBootstrapCmd = &cobra.Command{

--- a/cmd/gencommand_kubeconfig.go
+++ b/cmd/gencommand_kubeconfig.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandKubeconfigCmd = &cobra.Command{

--- a/cmd/gencommand_reset.go
+++ b/cmd/gencommand_reset.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandResetCmd = &cobra.Command{

--- a/cmd/gencommand_upgrade-k8s.go
+++ b/cmd/gencommand_upgrade-k8s.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandUpgradeK8sCmd = &cobra.Command{

--- a/cmd/gencommand_upgrade.go
+++ b/cmd/gencommand_upgrade.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var gencommandUpgradeCmd = &cobra.Command{

--- a/cmd/genconfig.go
+++ b/cmd/genconfig.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 )
 
 var (

--- a/cmd/genschema.go
+++ b/cmd/genschema.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/invopop/jsonschema"
 
 	"github.com/spf13/cobra"
@@ -24,7 +24,7 @@ var genschemaCmd = &cobra.Command{
 		r.RequiredFromJSONSchemaTags = true
 
 		// Doesn't work like I thought it should
-		// if err := r.AddGoComments("github.com/budimanjojo/talhelper/pkg/config", "./"); err != nil {
+		// if err := r.AddGoComments("github.com/budimanjojo/talhelper/v3/pkg/config", "./"); err != nil {
 		// 	log.Fatalf("failed to add go comments: %v", err)
 		// }
 		// if err := r.AddGoComments("github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1", "./"); err != nil {

--- a/cmd/gensecret.go
+++ b/cmd/gensecret.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"log"
 
-	"github.com/budimanjojo/talhelper/pkg/generate"
+	"github.com/budimanjojo/talhelper/v3/pkg/generate"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/genurl.go
+++ b/cmd/genurl.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/genurl_installer.go
+++ b/cmd/genurl_installer.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 	"github.com/spf13/cobra"
 )

--- a/cmd/genurl_iso.go
+++ b/cmd/genurl_iso.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 	"github.com/spf13/cobra"
 )

--- a/cmd/validate_nodeconfig.go
+++ b/cmd/validate_nodeconfig.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/validate_talconfig.go
+++ b/cmd/validate_talconfig.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/substitute"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-nIAi9NvwNsOCUAjBKbs07Zxsm7d6JMyGDQBbZu0wb/g=";
 
-  ldflags = [ "-s -w -X github.com/budimanjojo/talhelper/cmd.version=v${version}" ];
+  ldflags = [ "-s -w -X github.com/budimanjojo/talhelper/v3/cmd.version=v${version}" ];
 
   doCheck = false; # no tests
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/budimanjojo/talhelper
+module github.com/budimanjojo/talhelper/v3
 
 go 1.22.3
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/budimanjojo/talhelper/cmd"
+	"github.com/budimanjojo/talhelper/v3/cmd"
 )
 
 func main() {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/substitute"
+	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
 	"github.com/fatih/color"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -13,7 +13,7 @@ func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
 func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
 		// global patches should get applied first
-		// https://github.com/budimanjojo/talhelper/issues/388
+		// https://github.com/budimanjojo/talhelper/v3/issues/388
 		patch.Patches = append(src.Patches, patch.Patches...)
 	}
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -13,7 +13,7 @@ func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
 func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
 		// global patches should get applied first
-		// https://github.com/budimanjojo/talhelper/v3/issues/388
+		// https://github.com/budimanjojo/talhelper/issues/388
 		patch.Patches = append(src.Patches, patch.Patches...)
 	}
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {

--- a/pkg/config/patch.go
+++ b/pkg/config/patch.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/budimanjojo/talhelper/pkg/patcher"
+	"github.com/budimanjojo/talhelper/v3/pkg/patcher"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/generate/command.go
+++ b/pkg/generate/command.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/patcher"
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/patcher"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 )
 
 // GenerateConfig takes `TalhelperConfig` and path to encrypted `secretFile` and generates

--- a/pkg/generate/secret.go
+++ b/pkg/generate/secret.go
@@ -1,9 +1,9 @@
 package generate
 
 import (
-	talhelperCfg "github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/secret"
-	"github.com/budimanjojo/talhelper/pkg/talos"
+	talhelperCfg "github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/secret"
+	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 )

--- a/pkg/patcher/patcher.go
+++ b/pkg/patcher/patcher.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/decrypt"
-	"github.com/budimanjojo/talhelper/pkg/substitute"
+	"github.com/budimanjojo/talhelper/v3/pkg/decrypt"
+	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/substitute/envsubst.go
+++ b/pkg/substitute/envsubst.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 
 	"github.com/a8m/envsubst"
-	"github.com/budimanjojo/talhelper/pkg/decrypt"
+	"github.com/budimanjojo/talhelper/v3/pkg/decrypt"
 	"github.com/joho/godotenv"
 )
 
@@ -26,7 +26,7 @@ func LoadEnvFromFiles(files []string) error {
 				return fmt.Errorf("trying to decrypt %s with sops: %s", file, err)
 			}
 
-			// See: https://github.com/budimanjojo/talhelper/issues/220
+			// See: https://github.com/budimanjojo/talhelper/v3/issues/220
 			env = stripYAMLDocDelimiter(env)
 			if err := LoadEnv(env); err != nil {
 				return fmt.Errorf("trying to load env from %s: %s", file, err)

--- a/pkg/substitute/envsubst.go
+++ b/pkg/substitute/envsubst.go
@@ -26,7 +26,7 @@ func LoadEnvFromFiles(files []string) error {
 				return fmt.Errorf("trying to decrypt %s with sops: %s", file, err)
 			}
 
-			// See: https://github.com/budimanjojo/talhelper/v3/issues/220
+			// See: https://github.com/budimanjojo/talhelper/issues/220
 			env = stripYAMLDocDelimiter(env)
 			if err := LoadEnv(env); err != nil {
 				return fmt.Errorf("trying to load env from %s: %s", file, err)

--- a/pkg/talos/extensionserviceconfig.go
+++ b/pkg/talos/extensionserviceconfig.go
@@ -1,7 +1,7 @@
 package talos
 
 import (
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime/extensions"
 )
 

--- a/pkg/talos/extensionserviceconfig_test.go
+++ b/pkg/talos/extensionserviceconfig_test.go
@@ -3,7 +3,7 @@ package talos
 import (
 	"testing"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/runtime/extensions"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/talos/input.go
+++ b/pkg/talos/input.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
-	"github.com/budimanjojo/talhelper/pkg/decrypt"
-	"github.com/budimanjojo/talhelper/pkg/substitute"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/decrypt"
+	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
 	tconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"

--- a/pkg/talos/input_test.go
+++ b/pkg/talos/input_test.go
@@ -3,7 +3,7 @@ package talos
 import (
 	"testing"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/talos/networkconfig.go
+++ b/pkg/talos/networkconfig.go
@@ -3,7 +3,7 @@ package talos
 import (
 	"bytes"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/talos/networkconfig_test.go
+++ b/pkg/talos/networkconfig_test.go
@@ -4,7 +4,7 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/network"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"gopkg.in/yaml.v3"

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -38,7 +38,7 @@ func GenerateNodeConfig(node *config.Node, input *generate.Input, iFactory *conf
 		}
 	}
 
-	// https://github.com/budimanjojo/talhelper/v3/issues/81
+	// https://github.com/budimanjojo/talhelper/issues/81
 	if input.Options.VersionContract.SecretboxEncryptionSupported() && input.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret != "" {
 		slog.Debug("encryption with secretbox is supported and AESCBCEncryptionSecret is not empty")
 		c.RawV1Alpha1().ClusterConfig.ClusterAESCBCEncryptionSecret = input.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 	taloscfg "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
@@ -38,7 +38,7 @@ func GenerateNodeConfig(node *config.Node, input *generate.Input, iFactory *conf
 		}
 	}
 
-	// https://github.com/budimanjojo/talhelper/issues/81
+	// https://github.com/budimanjojo/talhelper/v3/issues/81
 	if input.Options.VersionContract.SecretboxEncryptionSupported() && input.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret != "" {
 		slog.Debug("encryption with secretbox is supported and AESCBCEncryptionSecret is not empty")
 		c.RawV1Alpha1().ClusterConfig.ClusterAESCBCEncryptionSecret = input.Options.SecretsBundle.Secrets.AESCBCEncryptionSecret

--- a/pkg/talos/nodeconfig_test.go
+++ b/pkg/talos/nodeconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/talos/schematic.go
+++ b/pkg/talos/schematic.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"text/template"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 

--- a/pkg/talos/schematic_test.go
+++ b/pkg/talos/schematic_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 

--- a/pkg/talos/talosconfig.go
+++ b/pkg/talos/talosconfig.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/budimanjojo/talhelper/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 )
 


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/494

The only reason why v3 is created is to somehow fix the mistake I made
when bumping the project to v2. Apparently, having a `go` project
updated to v2 beyond will need some manual interventions that I didn't
know about.

The consequence is that the `go` module of this project after v2.0.0 tag
can't be imported from outside of this project because go require v2 to
be a separate module from v0 and v1 (https://go.dev/blog/v2-go-modules).

This commit will just bump the project to v3 because I've made too many
releases in v2 and fixing it will require a lot of headache.
