### PR TITLE
fix(genconfig): don't include the provided doc delimiter if exists

### DIFF
--- a/pkg/talos/networkconfig.go
+++ b/pkg/talos/networkconfig.go
@@ -81,7 +81,10 @@ func CombineYamlBytes(input [][]byte) []byte {
 	delimiter := []byte("---\n")
 	var result []byte
 	for k := range input {
-		result = append(result, delimiter...)
+		// https://github.com/budimanjojo/talhelper/issues/497
+		if !bytes.HasPrefix(input[k], delimiter) {
+			result = append(result, delimiter...)
+		}
 		result = append(result, input[k]...)
 	}
 	return result


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/497
