### PR TITLE
feat(code): make `versiontags` a type inside main go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	golang.org/x/mod v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.4.0
-	tsehelper v0.0.0-00010101000000-000000000000
 )
 
 require (
@@ -144,5 +143,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace tsehelper => ./hack/tsehelper

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -7,8 +7,8 @@ import (
 	"net/netip"
 	"slices"
 	"strings"
-	"tsehelper/pkg/versiontags"
 
+	"github.com/budimanjojo/talhelper/v3/pkg/config/schemas/versiontags"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 

--- a/pkg/config/schemas/versiontags/versiontags.go
+++ b/pkg/config/schemas/versiontags/versiontags.go
@@ -1,0 +1,70 @@
+package versiontags
+
+import (
+	"golang.org/x/mod/semver"
+)
+
+// TalosVersion is a struct that holds the Talos version and list of available Talos System Extensions.
+type TalosVersion struct {
+	Version          string    `json:"version"`
+	SystemExtensions []string  `json:"systemExtensions"`
+	Overlays         []Overlay `json:"overlays" yaml:"overlays"`
+}
+
+// Overlay is a struct that holds the Talos Overlay information.
+type Overlay struct {
+	Image  string `json:"image" yaml:"image"`
+	Name   string `json:"name" yaml:"name"`
+	Digest string `json:"digest" yaml:"digest"`
+}
+
+// TalosVersionTags is a struct that holds the list of TalosVersionTags for each Talos version returned by the registry.
+type TalosVersionTags struct {
+	Versions []TalosVersion `json:"versions"`
+}
+
+// Implement Contains on TalosVersionsTags.Versions
+func (v TalosVersionTags) Contains(s string) bool {
+	for _, a := range v.Versions {
+		if a.Version == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Implement Len interface on TalosVersionsTags.Versions
+func (v TalosVersionTags) Len() int {
+	return len(v.Versions)
+}
+
+func (v TalosVersionTags) Less(i, j int) bool {
+	return semver.Compare(v.Versions[i].Version, v.Versions[j].Version) < 0
+}
+
+func (v TalosVersionTags) Swap(i, j int) {
+	v.Versions[i], v.Versions[j] = v.Versions[j], v.Versions[i]
+}
+
+func (v TalosVersionTags) SliceIndex(s string) int {
+	for i, a := range v.Versions {
+		if a.Version == s {
+			return i
+		}
+	}
+	return -1
+}
+
+func (v TalosVersion) IsValidOverlay(o Overlay) bool {
+	for _, overlay := range v.Overlays {
+		if o.Name == overlay.Name {
+			if o.Image != overlay.Image {
+				return false
+			} else {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -8,8 +8,8 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"tsehelper/pkg/versiontags"
 
+	"github.com/budimanjojo/talhelper/v3/pkg/config/schemas/versiontags"
 	"github.com/gookit/validate"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/net"


### PR DESCRIPTION
This will make the main talhelper module `go get` able.

After I publish a new release with this PR merged, I will need to also update the code in `tsehelper` to use this type for DRY reason.

Fixes: https://github.com/budimanjojo/talhelper/issues/516
