### PR TITLE
Link users to docs on errors

### DIFF
--- a/cmd/validate_talconfig.go
+++ b/cmd/validate_talconfig.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"os"
 
 	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
@@ -30,7 +29,7 @@ var validateTHCmd = &cobra.Command{
 
 		slog.Debug("start loading and validating config file")
 		slog.Debug(fmt.Sprintf("reading %s", cfg))
-		cfgByte, err := os.ReadFile(cfg)
+		cfgByte, err := config.FromFile(cfg)
 		if err != nil {
 			log.Fatalf("failed to read config file: %s", err)
 		}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -17,7 +17,7 @@ import (
 func LoadAndValidateFromFile(filePath string, envPaths []string, showWarns bool) (*TalhelperConfig, error) {
 	slog.Debug("start loading and validating config file")
 	slog.Debug(fmt.Sprintf("reading %s", filePath))
-	cfgByte, err := os.ReadFile(filePath)
+	cfgByte, err := FromFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %s", err)
 	}
@@ -100,7 +100,7 @@ func NewFromByte(source []byte) (*TalhelperConfig, error) {
 // NewFromFile takes a file path and convert the contents into Talhelper config.
 // It also returns an error, if any.
 func NewFromFile(path string) (c *TalhelperConfig, err error) {
-	source, err := fromFile(path)
+	source, err := FromFile(path)
 	if err != nil {
 		return c, err
 	}
@@ -108,9 +108,13 @@ func NewFromFile(path string) (c *TalhelperConfig, err error) {
 	return newConfig(source)
 }
 
-// fromFile is a wrapper for `os.ReadFile`.
-func fromFile(path string) ([]byte, error) {
-	return os.ReadFile(path)
+// FromFile is a wrapper for `os.ReadFile` with modified error if path doesn't exist.
+func FromFile(path string) ([]byte, error) {
+	b, err := os.ReadFile(path)
+	if err != nil && os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s doesn't exist. Refer to this docs for more information on how to create one: https://budimanjojo.github.io/talhelper/latest/guides/#example-talconfigyaml", path)
+	}
+	return b, err
 }
 
 // newConfig takes bytes and convert it into Talhelper config.


### PR DESCRIPTION
Closes: https://github.com/budimanjojo/talhelper/issues/492

Although this doesn't completely do what the original issue is suggesting, but this looks like a better approach.
Users should look at the documentation before using this program.

This PR is not completely done yet.
Maybe docs also need improvement or maybe there are more error messages that needs to be linked to the related docs etc.
