### PR TITLE
fix: Dockerfile base image and Docker Workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -9,6 +9,10 @@ on:
     paths:
       - Dockerfile
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -12,11 +12,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: The tag to apply to the docker image.
+        description: Docker Tag
         default: ""
         required: false    
       dryRun:
-        description: Whether or not to push the image to the container registry.
+        description: Dry Run
         default: "true"
         required: false
 

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -48,7 +48,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/talhelper
           tags: |
             ${{ github.event.release.tag_name }}
-            ${{ input.tag }}
+            ${{ github.event.inputs.tag }}
             latest
 
       - name: Build and push by digest

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ github.event_name == 'release' || github.event.inputs.dryRun == 'false' }}
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ github.event_name == 'release' || github.event.inputs.dryRun == 'false' }}
-          platforms: linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7
+          platforms: linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -8,10 +8,17 @@ on:
     branches: ["main"]
     paths:
       - Dockerfile
-
-permissions:
-  contents: read
-  packages: write
+      - .github/workflows/docker-build-and-push.yaml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The tag to apply to the docker image.
+        default: ""
+        required: false    
+      dryRun:
+        description: Whether or not to push the image to the container registry.
+        default: "true"
+        required: false
 
 jobs:
   build:
@@ -41,12 +48,13 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/talhelper
           tags: |
             ${{ github.event.release.tag_name }}
+            ${{ input.tag }}
             latest
 
       - name: Build and push by digest
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.event_name == 'release' }}
+          push: ${{ github.event_name == 'release' || input.dryRun == 'false' }}
           platforms: linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -2,28 +2,20 @@
 name: Docker Build and Push
 
 on:
-  push:
-    tags:
-      - "*"
-
-env:
-  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/talhelper
+  release:
+    types: [created]
+  pull_request:
+    branches: ["main"]
+    paths:
+      - Dockerfile
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
-          - linux/arm64
 
     steps:
       - name: Checkout the Repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.1.7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -42,70 +34,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ghcr.io/${{ github.repository_owner }}/talhelper
+          tags: |
+            ${{ github.event.release.tag_name }}
+            latest
 
       - name: Build and push by digest
-        id: build
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ github.event_name == 'release' }}
+          platforms: linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          build-args: |
-            VERSION=${{ github.ref_name }}
-
-      - name: Export digest
-        id: export
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          echo "digest=${digest#sha256:}" | tee $GITHUB_OUTPUT
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.export.outputs.digest }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          IMAGES=$(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-          docker buildx imagetools create $TAGS $IMAGES
-
-      - name: Inspect image
-        env:
-          IMAGE: "${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}"
-        run: docker buildx imagetools inspect $IMAGE
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -46,3 +46,5 @@ jobs:
           platforms: linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -3,9 +3,9 @@ name: Docker Build and Push
 
 on:
   release:
-    types: [created]
+    types: [ "created" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main", "master" ]
     paths:
       - Dockerfile
       - .github/workflows/docker-build-and-push.yaml

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Build and push by digest
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.event_name == 'release' || input.dryRun == 'false' }}
+          push: ${{ github.event_name == 'release' || github.event.inputs.dryRun == 'false' }}
           platforms: linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ## ================================================================================================
 ## Builder Stage -> creating the binary
 ## ================================================================================================
-FROM golang:1.22.5-alpine as builder
+FROM golang:1.22.5-alpine AS builder
 ARG VERSION
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ## ================================================================================================
 ## Builder Stage -> creating the binary
 ## ================================================================================================
-FROM golang:1.22.3-alpine3.18 as builder
+FROM golang:1.22.5-alpine as builder
 ARG VERSION
 
 WORKDIR /build


### PR DESCRIPTION
In this PR I tried to accomplish the following things:

- fix the problem with renovate not updating the base image in our Dockerfile to go `1.22.5` (probably due to being overly specific on the alpine version in the tag)
- simplify the docker build workflow quite a bit and keep it to only amd64 and arm64 (no more armv6 and armv7 as they were either making the workflow more complicated than it should be or take twice as long)
- modify the triggers for the docker build workflow such that it is now triggered:
  - when a new release is created -> build and push a docker image with the same tag as the release
  - on any PR activity targeting the main/master branch that has modified any docker-related file -> only build (no push) the image so that we can basically auto-test renovate PRs to make sure the docker build would still work
  - manually trigger a new docker build and release
  
P.S.: sorry for bundling together multiple changes. I can split this into 2 PRs if needed