### PR TITLE
feat(validate): don't validate on selfhosted image factory

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -497,17 +497,26 @@ disableSearchDomain: true
 </tr>
 
 <tr markdown="1">
-<td markdown="1">`machineDisks`</td>
-<td markdown="1">[][MachineDisk](#machinedisk)</td>
-<td markdown="1">List of additional disks to partition, format, mount.<details><summary>*Show example*</summary>
+<td markdown="1">`noSchematicValidate`</td>
+<td markdown="1">bool</td>
+<td markdown="1">Whether to skip schematic validation.<details><summary>*Show example*</summary>
 ```yaml
-machineDisks:
-  - device: /dev/disk/by-id/ata-CT500MX500SSD1_2149E5EC1D9D
-    partitions:
-      - mountpoint: /var/mnt/sata
+noSchematicValidate: true
 ```
 </summary></td>
-<td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`disableSearchDomain`</td>
+<td markdown="1">bool</td>
+<td markdown="1">Whether to disable generating default search domain.<details><summary>*Show example*</summary>
+```yaml
+disableSearchDomain: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type NodeConfigs struct {
 	ExtraManifests      []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
 	Patches             []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
 	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
+	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
 	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
 	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
 	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -56,7 +56,8 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeTaints(node, k, &result)
 		checkNodeMachineDisks(node, k, &result)
 		checkNodeMachineFiles(node, k, &result)
-		if c.GetImageFactory().RegistryURL == "factory.talos.dev" {
+		if c.GetImageFactory().RegistryURL == "factory.talos.dev" && !node.NoSchematicValidate {
+			slog.Debug(fmt.Sprintf("validating schematic with official Talos schematic for node %s", node.Hostname))
 			checkNodeSchematic(node, k, c.GetTalosVersion(), &result)
 		}
 		checkNodeNameServers(node, k, &result)

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -56,7 +56,9 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeTaints(node, k, &result)
 		checkNodeMachineDisks(node, k, &result)
 		checkNodeMachineFiles(node, k, &result)
-		checkNodeSchematic(node, k, c.GetTalosVersion(), &result)
+		if c.GetImageFactory().RegistryURL == "factory.talos.dev" {
+			checkNodeSchematic(node, k, c.GetTalosVersion(), &result)
+		}
 		checkNodeNameServers(node, k, &result)
 		checkNodeNetworkInterfaces(node, k, &result)
 		checkNodeIngressFirewall(node, k, &result)


### PR DESCRIPTION
fixes: https://github.com/budimanjojo/talhelper/issues/537

The validation only works for official Talos image factory anyway so it makes more sense if we just don't do validation altogether for selfhosted image factory.
