### PR TITLE
feat(config): add support for `nodeAnnotations`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -473,6 +473,18 @@ rack: rack1a
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`nodeAnnotations`</td>
+<td markdown="1">map[string]string</td>
+<td markdown="1">Annotations to be added to the node.<details><summary>*Show example*</summary>
+```yaml
+rack: rack1a
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`nodeTaints`</td>
 <td markdown="1">map[string]string</td>
 <td markdown="1">Node taints for the node.<details><summary>*Show example*</summary>

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -79,6 +79,8 @@ nodes:
     nodeLabels:
       rack: rack1a
       zone: us-east-1a
+    nodeAnnotations:
+      rack: rack1a
     nodeTaints:
       mytaint: mytaints:NoSchedule
     disableSearchDomain: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type Node struct {
 
 type NodeConfigs struct {
 	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node"`
+	NodeAnnotations     map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node"`
 	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
 	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
 	MachineFiles        []*v1alpha1.MachineFile        `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`

--- a/pkg/config/nodeconfigs_test.go
+++ b/pkg/config/nodeconfigs_test.go
@@ -13,6 +13,9 @@ func TestOverrideNodeConfigs(t *testing.T) {
 		NodeLabels: map[string]string{
 			"testkey": "testValue",
 		},
+		NodeAnnotations: map[string]string{
+			"testkey": "testValue",
+		},
 		Schematic: &schematic.Schematic{
 			Customization: schematic.Customization{
 				ExtraKernelArgs: []string{"enable=1"},
@@ -51,6 +54,9 @@ func TestOverrideNodeConfigs(t *testing.T) {
 		NodeConfigs: NodeConfigs{
 			NodeLabels: map[string]string{
 				"testkey": "overwritten",
+			},
+			NodeAnnotations: map[string]string{
+				"testkey": "testValue",
 			},
 			MachineDisks: []*v1alpha1.MachineDisk{
 				{

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -53,6 +53,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeIPAddress(node, k, &result)
 		checkNodeHostname(node, k, &result)
 		checkNodeLabels(node, k, &result)
+		checkNodeAnnotations(node, k, &result)
 		checkNodeTaints(node, k, &result)
 		checkNodeMachineDisks(node, k, &result)
 		checkNodeMachineFiles(node, k, &result)

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -291,6 +291,20 @@ func checkNodeLabels(node Node, idx int, result *Errors) *Errors {
 	return result
 }
 
+func checkNodeAnnotations(node Node, idx int, result *Errors) *Errors {
+	if node.NodeAnnotations != nil {
+		var messages *multierror.Error
+		if err := labels.ValidateAnnotations(node.NodeAnnotations); err != nil {
+			return result.Append(&Error{
+				Kind:    "InvalidNodeAnnotations",
+				Field:   getNodeFieldYamlTag(node, idx, "NodeAnnotations"),
+				Message: formatError(multierror.Append(messages, err)),
+			})
+		}
+	}
+	return result
+}
+
 func checkNodeTaints(node Node, idx int, result *Errors) *Errors {
 	if node.NodeTaints != nil {
 		var messages *multierror.Error

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -98,6 +98,11 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineKernel.KernelModules = node.KernelModules
 	}
 
+	if node.NodeAnnotations != nil {
+		slog.Debug(fmt.Sprintf("setting node annotations for %s", node.NodeAnnotations))
+		cfg.RawV1Alpha1().MachineConfig.MachineNodeAnnotations = node.NodeAnnotations
+	}
+
 	if node.NodeLabels != nil {
 		slog.Debug(fmt.Sprintf("setting node labels to %s", node.NodeLabels))
 		cfg.RawV1Alpha1().MachineConfig.MachineNodeLabels = node.NodeLabels


### PR DESCRIPTION
This add the ability to define node annotations in `talconfig.yaml` file.

Not sure how the `talosctl` will react to when the version is below Talos v1.8 because this feature is not available before this version.
