### PR TITLE
Use full yaml parsing for more correct comment stripping

### DIFF
--- a/pkg/substitute/envsubst.go
+++ b/pkg/substitute/envsubst.go
@@ -79,6 +79,7 @@ func stripYamlComment(file []byte) ([]byte, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(file))
 	var out bytes.Buffer
 	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
 	for {
 		var node yaml.Node
 		err := decoder.Decode(&node)
@@ -89,7 +90,10 @@ func stripYamlComment(file []byte) ([]byte, error) {
 			return nil, err
 		}
 		removeCommentsRec(&node)
-		encoder.Encode(&node)
+		err = encoder.Encode(&node)
+		if err != nil {
+			return nil, err
+		}
 	}
 	err := encoder.Close()
 	if err != nil {

--- a/pkg/substitute/envsubst_test.go
+++ b/pkg/substitute/envsubst_test.go
@@ -87,7 +87,7 @@ default: default value
 func TestComplexCommentStrip(t *testing.T) {
 	file := `a1: '123!@# not a comment'
 a2: |
-    # not a comment
+  # not a comment
 b1: '"' # comment
 b2: "'" # comment
 b3: "\"" # comment
@@ -95,7 +95,7 @@ b3: "\"" # comment
 
 	expected := `a1: '123!@# not a comment'
 a2: |
-    # not a comment
+  # not a comment
 b1: '"'
 b2: "'"
 b3: "\""
@@ -103,6 +103,6 @@ b3: "\""
 
 	result, _ := SubstituteEnvFromByte([]byte(file))
 	if expected != string(result) {
-		t.Errorf("got %s, want %s", string(result), expected)
+		t.Errorf("got\n%s,\bwant\n%s", string(result), expected)
 	}
 }

--- a/pkg/substitute/envsubst_test.go
+++ b/pkg/substitute/envsubst_test.go
@@ -83,3 +83,26 @@ default: default value
 		}
 	}
 }
+
+func TestComplexCommentStrip(t *testing.T) {
+	file := `a1: '123!@# not a comment'
+a2: |
+    # not a comment
+b1: '"' # comment
+b2: "'" # comment
+b3: "\"" # comment
+`
+
+	expected := `a1: '123!@# not a comment'
+a2: |
+    # not a comment
+b1: '"'
+b2: "'"
+b3: "\""
+`
+
+	result, _ := SubstituteEnvFromByte([]byte(file))
+	if expected != string(result) {
+		t.Errorf("got %s, want %s", string(result), expected)
+	}
+}


### PR DESCRIPTION
Hi, I was encountering a bug where an `inlineManifest` added via patch in my `talconfig.yaml` was ending up malformed in the node config generated by talhelper.

For example, my patch had this line:
```yaml
- '--log-format [%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v'
```
Which was being modified to:
```yaml
- '--log-format [%Y-%m-%d %T.%e][%t][%l][%n] [%g:
```

I tracked the issue down to the yaml comment stripping phase: the current regex is a bit overzealous and thought there was a comment in that string. Seeing the `// FIXME use better logic than regex` comment there, I thought I'd take a shot at improving it.

The approach I went with is a little heavyweight. The input is fully parsed into a yaml AST, operated on, and then re-rendered to bytes. This is probably best for correctness, but I would also be up for writing something lighter if preferred. I can think of a few ways of just modifying the regex to fix my case, for instance.

---
There are also behavior changes beyond unambiguous bug-fixing, which should be considered before merging. 

- "Comments" that are within multiline strings that happen to be embedded yaml are no longer stripped (because they are actually part of the content of the string). It could cause problems if anyone was relying on "commented out" code in strings being excluded from environment variable substitution. For example, this will error when `MYENV2` is not defined:
  ```yaml
  patches:
   - |-
    machine:
      env:
        MYENV: value
        # MYENV2: ${MYENV2}
  ```
- While semantics should be preserved, sometimes style choices are not.
  The output of `stripYamlComment` will always be indented with 4 spaces, regardless of input style.
  Multiline strings are sometimes converted to double quoted ones. For instance, when they contain lines with trailing whitespace:
  ```yaml
  foo: | # note the trailing spaces on the following line
    trailing:    
    bar
  ```
  will be turned into:
  ```yaml
  foo: "trailing:    \nbar\n"
  ```
  ([seems](https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/emitterc.go#L1393) [intentional](https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/emitterc.go#L1041), but I am not entirely sure why)

- Most likely some other things I haven't thought of.

This might constitute a version change?

---
Thanks for your consideration and your work on this tool!