### PR TITLE
chore(devcontainer): Update configuration and add CI workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+## ================================================================================================
+# Utility versions
+## ================================================================================================
+ARG KUBECTL_VERSION=1.31.0
+ARG TALOSCTL_VERSION=v1.7.6
+ARG GOLINT_VERSION=v1.60.3-alpine
+ARG GORELEASER_VERSION=v2.2.0
+ARG SOPS_VERSION=v3.9.0-alpine
+ARG AGE_VERSION=v1.2.0
+ARG AGE_KEYGEN_VERSION=V1.2.0
+
+
+FROM bitnami/kubectl:${KUBECTL_VERSION} AS kubectl
+FROM ghcr.io/siderolabs/talosctl:${TALOSCTL_VERSION} AS talosctl
+FROM golangci/golangci-lint:${GOLINT_VERSION} AS golangci-lint
+FROM goreleaser/goreleaser:${GORELEASER_VERSION} AS goreleaser
+FROM ghcr.io/getsops/sops:${SOPS_VERSION} AS sops
+FROM ghcr.io/mirceanton/age:${AGE_VERSION} AS age
+FROM ghcr.io/mirceanton/age-keygen:${AGE_KEYGEN_VERSION} AS age-keygen
+
+
+## ================================================================================================
+## Main image
+## ================================================================================================
+FROM mcr.microsoft.com/devcontainers/go:1.23-bookworm@sha256:a3403234ec01e5383f63414aabfd3e2703a4c1e44b260354495c6f1e8cdc7594 AS workspace
+
+COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+COPY --from=talosctl /talosctl /usr/local/bin/talosctl
+COPY --from=golangci-lint /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+COPY --from=goreleaser /usr/bin/goreleaser /usr/local/bin/goreleaser
+COPY --from=sops /usr/local/bin/sops /usr/local/bin/sops
+COPY --from=age /age /usr/local/bin/age
+COPY --from=age-keygen /age-keygen /usr/local/bin/age-keygen
+
+RUN kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl.bash > /dev/null
+RUN talosctl completion bash | sudo tee /etc/bash_completion.d/talosctl.bash > /dev/null
+RUN golangci-lint completion bash | sudo tee /etc/bash_completion.d/golangci-lint.bash > /dev/null
+RUN goreleaser completion bash | sudo tee /etc/bash_completion.d/goreleaser.bash > /dev/null
+
+USER vscode
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,12 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "talhelper-devcontainer",
-
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"installDockerBuildx": true,
-			"version": "latest",
-			"dockerDashComposeVersion": "v2"
-		},
-		"ghcr.io/devcontainers-contrib/features/mkdocs:2": {
-			"version": "latest",
-			"plugins": "mkdocs-material pymdown-extensions mkdocstrings[crystal,python] mkdocs-monorepo-plugin mkdocs-pdf-export-plugin mkdocs-awesome-pages-plugin mike"
-		},
-		"ghcr.io/devcontainers-contrib/features/sops:1": {
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers-contrib/features/age:1": {
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers-contrib/features/age-keygen:1": {
-			"version": "latest"
-		}
-	}
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+	"remoteUser": "vscode",
+	"containerUser": "vscode",
+	"updateRemoteUserUID": true
 }

--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: DevContainer Docker Build
+
+on:
+  workflow_dispatch: {}
+
+  pull_request:
+    paths:
+      - ".github/workflows/devcontainer-build.yaml"
+      - ".devcontainer/Dockerfile"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v4.1.7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Image
+        uses: docker/build-push-action@v6
+        with:
+          push: false # don't push, this workflow just tests the build process won't fail
+          platforms: linux/amd64
+          tags: "test"
+          context: .devcontainer
+          file: .devcontainer/Dockerfile


### PR DESCRIPTION
I noticed the devcontainer configuration was failing. There was apparently some issue with the `age` installer or something like that.

To be fully honest I never really liked those devcontainer features as they're too much of a black box and I don't have much visibility into how they're doing their thing. With this approach we just collect all of the binaries we need from official and trusted docker images to piece together a working config.