### PR TITLE
feat(cmd): generate autocompletion for `--node` flag

### DIFF
--- a/cmd/gencommand.go
+++ b/cmd/gencommand.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/budimanjojo/talhelper/v3/cmd/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -24,4 +25,5 @@ func init() {
 	gencommandCmd.PersistentFlags().StringSliceVar(&gencommandEnvFile, "env-file", []string{"talenv.yaml", "talenv.sops.yaml", "talenv.yml", "talenv.sops.yml"}, "List of files containing env variables for config file")
 	gencommandCmd.PersistentFlags().StringSliceVar(&gencommandExtraFlags, "extra-flags", []string{}, "List of additional flags that will be injected into the generated commands.")
 	gencommandCmd.PersistentFlags().StringVarP(&gencommandNode, "node", "n", "", "A specific node to generate the command for. If not specified, will generate for all nodes.")
+	_ = helpers.MakeNodeCompletion(gencommandCmd)
 }

--- a/cmd/genurl.go
+++ b/cmd/genurl.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/budimanjojo/talhelper/v3/cmd/helpers"
 	"github.com/budimanjojo/talhelper/v3/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -34,4 +35,6 @@ func init() {
 	genurlCmd.PersistentFlags().StringSliceVarP(&genurlKernelArgs, "kernel-arg", "k", []string{}, "Kernel arguments to be passed to the image kernel (ignored when talconfig.yaml is found)")
 	genurlCmd.PersistentFlags().BoolVar(&genurlOfflineMode, "offline-mode", false, "Generate schematic ID without doing POST request to image-factory")
 	genurlCmd.PersistentFlags().BoolVar(&genurlSecureboot, "secure-boot", false, "Whether to generate Secure Boot enabled URL")
+
+	_ = helpers.MakeNodeCompletion(genurlCmd)
 }

--- a/cmd/helpers/completions.go
+++ b/cmd/helpers/completions.go
@@ -1,0 +1,27 @@
+package helpers
+
+import (
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// MakeNodeCompletion is a wrapper for `cobra.Command.RegisterFlagCompletionFunc`
+// to reuse in commands that want to have `--node` flag completion
+func MakeNodeCompletion(cmd *cobra.Command) error {
+	return cmd.RegisterFlagCompletionFunc("node", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		var nodes []string
+		thCfg, _ := cmd.Flags().GetString("config-file")
+		thEnvFiles, _ := cmd.Flags().GetStringSlice("env-file")
+
+		cfg, err := config.LoadAndValidateFromFile(thCfg, thEnvFiles, false)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		for i := range cfg.Nodes {
+			nodes = append(nodes, cfg.Nodes[i].Hostname)
+			nodes = append(nodes, cfg.Nodes[i].IPAddress)
+		}
+		return nodes, cobra.ShellCompDirectiveNoFileComp
+	})
+}


### PR DESCRIPTION
With this PR, you will now get shell completion for `--node` flag.

It will work even when you're not inside the directory where `talconfig.yaml` file exists by providing the `--config-file` and `env-file` flag.

Example scenarios:

You are in the directory where `talconfig.yaml` exists
* You type `talhelper gencommand upgrade --node` and press `Tab`.
* Your shell will provide list of hostnames and IP addresses that you define inside `talconfig.yaml`.

You are not in the directory where `talconfig.yaml` exists
* You type `talhelper gencommand upgrade -c anotherdir/talconfig.yaml --env-file anotherdir/talenv.yaml -n` and press Tab.
* Your shell will provide list of hostnames and IP addresses that you define inside `anotherdir/talconfig.yaml`.

But, nothing is perfect and there's a problem that I found when you're in the second scenario.
If your `anotherdir/talconfig.yaml` has a key that needs relative paths of the `talconfig.yaml` file, then the completion won't show up because the `LoadAndValidateFromFile()` function used will report error and refuses to continue.
Example of this are you have `patches` or `machineFiles` with the content being `@./anotherfile`.

I think the solution to the problem is to load the config file without validation because all we need is the `hostname` and `ipAddress` key of the node to work. But then what if the `nodes` is defined incorrectly? Or we can make a simple struct that only consist of the `nodes` with `hostname` and `ipAddress` and ignore all the other keys, but it seems wasteful and increase the sourcecode just for shell autocompletion. I might decide to improve this in the future.
