### PR TITLE
fix: Add support for relative paths when called from another dir

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -17,6 +17,7 @@ import (
 func LoadAndValidateFromFile(filePath string, envPaths []string, showWarns bool) (*TalhelperConfig, error) {
 	slog.Debug("start loading and validating config file")
 	slog.Debug(fmt.Sprintf("reading %s", filePath))
+
 	cfgByte, err := FromFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %s", err)
@@ -30,6 +31,12 @@ func LoadAndValidateFromFile(filePath string, envPaths []string, showWarns bool)
 	cfgByte, err = substitute.SubstituteEnvFromByte(cfgByte)
 	if err != nil {
 		return nil, fmt.Errorf("failed to substitute env: %s", err)
+	}
+
+	slog.Debug("substituting relative paths with absolute paths")
+	cfgByte, err = substitute.SubstituteRelativePaths(filePath, cfgByte)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate relative paths: %s", err)
 	}
 
 	cfg, err := NewFromByte(cfgByte)

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -15,17 +15,20 @@ import (
 // file to the relative paths in the config file so that their evaluation no longer fails.
 func SubstituteRelativePaths(configFilePath string, yamlContent []byte) ([]byte, error) {
 	// Get the directory of the YAML file
-	yamlDir := filepath.Dir(configFilePath)
+	absolutePath, err := filepath.Abs(filepath.Dir(configFilePath))
+	if err != nil {
+		return nil, err
+	}
 
 	// Parse the YAML content
 	var data interface{}
-	err := yaml.Unmarshal(yamlContent, &data)
+	err = yaml.Unmarshal(yamlContent, &data)
 	if err != nil {
 		return nil, err
 	}
 
 	// Process the data
-	data = processNode(data, []string{}, yamlDir)
+	data = processNode(data, []string{}, absolutePath)
 
 	// Marshal back to YAML
 	newYamlContent, err := yaml.Marshal(data)

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -40,7 +40,6 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 			newPath := append(path, keyStr)
 			newMap[k] = processNode(v, newPath, yamlDir)
 		}
-
 		return newMap
 
 	case []interface{}:
@@ -49,7 +48,6 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 			newPath := append(path, fmt.Sprintf("[%d]", i))
 			newArray[i] = processNode(v, newPath, yamlDir)
 		}
-
 		return newArray
 
 	case string:
@@ -63,10 +61,9 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 				}
 			}
 		}
-
 		return n
+
 	default:
-		// For other types, return as is
 		return n
 	}
 }

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -1,0 +1,53 @@
+package substitute
+
+import (
+	"bufio"
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+func SubstituteRelativePaths(configFilePath string, yamlContent []byte) ([]byte, error) {
+	// Get the directory of the YAML file
+	yamlDir := filepath.Dir(configFilePath)
+
+	// Create a scanner to read through the YAML content
+	scanner := bufio.NewScanner(bytes.NewReader(yamlContent))
+
+	// Buffer to hold the processed lines
+	var processedLines []string
+
+	// Start reading the file, line by line
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Look for lines containing "@"
+		if strings.Contains(line, "@") {
+			// Split by "@" to isolate the relative path
+			parts := strings.SplitN(line, "@", 2)
+
+			if len(parts) == 2 && len(strings.TrimSpace(parts[1])) > 0 {
+				// Get the relative path and resolve to absolute
+				relativePath := strings.TrimSpace(parts[1])
+				absolutePath := filepath.Join(yamlDir, relativePath)
+
+				// Reconstruct the line with the absolute path
+				line = parts[0] + "@" + absolutePath
+			}
+		}
+
+		// Append the processed line to the result
+		processedLines = append(processedLines, line)
+	}
+
+	// Check for scanning errors
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// Join all processed lines back into a single string and convert to []byte
+	result := strings.Join(processedLines, "\n")
+
+	// Return the processed file
+	return []byte(result), nil
+}

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// SubstituteRelativePaths will replace all relative paths in the config file to new paths,
+// relative to the working dir from which the CLI has been called.
+// When using the `--config-file` flag to point to a file not in the current dir,
+// relative path evaluation would fail. This function basically prepends the path to the config
+// file to the relative paths in the config file so that their evaluation no longer fails.
 func SubstituteRelativePaths(configFilePath string, yamlContent []byte) ([]byte, error) {
 	// Get the directory of the YAML file
 	yamlDir := filepath.Dir(configFilePath)

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -75,7 +75,7 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 
 func shouldSubstitute(path []string) bool {
 	for _, p := range path {
-		if p == "machineFiles" || p == "patches" {
+		if p == "machineFiles" || p == "patches" || p == "extraManifests" {
 			return true
 		}
 	}

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -52,7 +52,7 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 
 	case string:
 		if shouldSubstitute(path) {
-			if strings.Contains(n, "@") {
+			if strings.HasPrefix(n, "@") {
 				parts := strings.SplitN(n, "@", 2)
 				if len(parts) == 2 && len(strings.TrimSpace(parts[1])) > 0 {
 					relativePath := strings.TrimSpace(parts[1])

--- a/pkg/substitute/pathsubst_test.go
+++ b/pkg/substitute/pathsubst_test.go
@@ -1,0 +1,182 @@
+package substitute
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestSubstituteRelativePaths(t *testing.T) {
+	// Define the path to the YAML file (for testing purposes, we use a dummy path)
+	configFilePath := "/path/to/config.yaml"
+
+	// Define test cases
+	tests := []struct {
+		name           string
+		yamlContent    string
+		expectedOutput string
+	}{
+		{
+			name: "Substitute in machineFiles",
+			yamlContent: `
+machineFiles:
+  - content: "@./relative/path/file.txt"
+    permissions: 0o644
+    path: /var/etc/tailscale/auth.env
+    op: create
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "@/path/to/relative/path/file.txt"
+    permissions: 0o644
+    path: /var/etc/tailscale/auth.env
+    op: create
+`,
+		},
+		{
+			name: "Substitute in patches",
+			yamlContent: `
+patches:
+  - "@./relative/patch.yaml"
+`,
+			expectedOutput: `
+patches:
+  - "@/path/to/relative/patch.yaml"
+`,
+		},
+		{
+			name: "No substitution outside specified sections",
+			yamlContent: `
+nodes:
+  - hostname: kworker1
+    ipAddress: "@./should/not/replace"
+`,
+			expectedOutput: `
+nodes:
+  - hostname: kworker1
+    ipAddress: "@./should/not/replace"
+`,
+		},
+		{
+			name: "Substitute in nested machineFiles",
+			yamlContent: `
+nodes:
+  - hostname: kmaster1
+    machineFiles:
+      - content: "@./nested/path/file.conf"
+        path: /etc/config.conf
+`,
+			expectedOutput: `
+nodes:
+  - hostname: kmaster1
+    machineFiles:
+      - content: "@/path/to/nested/path/file.conf"
+        path: /etc/config.conf
+`,
+		},
+		{
+			name: "Substitute in nested patches",
+			yamlContent: `
+controlPlane:
+  patches:
+    - "@./control/plane/patch.yaml"
+`,
+			expectedOutput: `
+controlPlane:
+  patches:
+    - "@/path/to/control/plane/patch.yaml"
+`,
+		},
+		{
+			name: "Multiple substitutions",
+			yamlContent: `
+machineFiles:
+  - content: "@./file1.txt"
+patches:
+  - "@./patch1.yaml"
+nodes:
+  - hostname: node1
+    ipAddress: "@./should/not/replace"
+    machineFiles:
+      - content: "@./node1/file2.txt"
+    patches:
+      - "@./node1/patch2.yaml"
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "@/path/to/file1.txt"
+patches:
+  - "@/path/to/patch1.yaml"
+nodes:
+  - hostname: node1
+    ipAddress: "@./should/not/replace"
+    machineFiles:
+      - content: "@/path/to/node1/file2.txt"
+    patches:
+      - "@/path/to/node1/patch2.yaml"
+`,
+		},
+		{
+			name: "No substitution when '@' is not at the beginning",
+			yamlContent: `
+machineFiles:
+  - content: "example@./should/not/replace"
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "example@./should/not/replace"
+`,
+		},
+		{
+			name: "Handle empty '@' reference",
+			yamlContent: `
+machineFiles:
+  - content: "@"
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "@"
+`,
+		},
+		{
+			name: "Handle missing relative path after '@'",
+			yamlContent: `
+machineFiles:
+  - content: "@ "
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "@ "
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputBytes, err := SubstituteRelativePaths(configFilePath, []byte(tt.yamlContent))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			var expectedData interface{}
+			err = yaml.Unmarshal([]byte(tt.expectedOutput), &expectedData)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal expected output: %v", err)
+			}
+
+			var actualData interface{}
+			err = yaml.Unmarshal(outputBytes, &actualData)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal actual output: %v", err)
+			}
+
+			if !reflect.DeepEqual(actualData, expectedData) {
+				// For better error messages, re-marshal the data to YAML strings
+				expectedYAML, _ := yaml.Marshal(expectedData)
+				actualYAML, _ := yaml.Marshal(actualData)
+				t.Errorf("Output mismatch.\nExpected:\n%s\nGot:\n%s", expectedYAML, actualYAML)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Really not sure what to call this PR :)))

Basically this is a very trivial PoC to validate that we can rewrite the relative paths in relation to the directory from which `talhelper` has been called given that we have the path to the config file in the `--config-file` flag.