### PR TITLE
fix(genconfig): skip applying patch that contains empty file

### DIFF
--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -38,6 +38,7 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 		}
 
 		if len(node.Patches) != 0 {
+			slog.Debug(fmt.Sprintf("applying node specific patches to %s", node.Hostname))
 			cfg, err = patcher.PatchesPatcher(node.Patches, cfg)
 			if err != nil {
 				return err
@@ -45,6 +46,7 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 		}
 
 		if len(c.Patches) > 0 {
+			slog.Debug(fmt.Sprintf("applying global patches to %s", node.Hostname))
 			cfg, err = patcher.PatchesPatcher(c.Patches, cfg)
 			if err != nil {
 				return err

--- a/pkg/patcher/patcher_test.go
+++ b/pkg/patcher/patcher_test.go
@@ -78,6 +78,7 @@ func TestPatchesPatcher(t *testing.T) {
 		"@testdata/strategic.yaml",
 		"@testdata/patch.yaml",
 		"@testdata/encrypted.sops.yaml",
+		"@testdata/emptyfile.yaml",
 		`[{"op":"add","path":"/machine/network/interfaces/0/dhcp","value": false}]`,
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/645
