### PR TITLE
Add flake parts easy overlay for more idiomatic experience for nix users.

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -45,6 +45,32 @@ You can get `talhelper` as [Nix Flakes](https://nixos.wiki/wiki/Flakes) from the
     ```
 
 - The package is now available at `packages.<system>.default` of the flake. You can call it in your `home.packages` or `environment.systemPackages` or `devShell` by referencing the input as `inputs.talhelper.packages.<system>.default`.
+- Additionally we provide a convenient overlay for your nixpkgs
+    ```nix
+    {
+      ...
+      pkgs = import nixpkgs {
+        overlays = [
+          inputs.talhelper.overlays.default
+        ];
+      };
+    }
+    # In any of the places you define packages
+    {
+      # Nixos
+      environment.systemPackages = with pkgs; [
+        talhelper
+      ];
+      # Home Manager
+      home.packages = with pkgs; [
+        talhelper
+      ];
+      # Flakes
+      pkgs.mkShell = with pkgs; [
+        talhelper
+      ];
+    }
+    ```
 
 ## Using Pacman
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,10 @@
             #   })
             # ];
           };
-          packages.default = pkgs.callPackage ./default.nix { };
+          packages = rec {
+            default = talhelper;
+            talhelper = pkgs.callPackage ./default.nix { };
+          };
           devShells.default =
             with pkgs;
             mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,15 @@
         "x86_64-darwin"
         "aarch64-darwin"
       ];
+      imports = [
+        inputs.flake-parts.flakeModules.easyOverlay
+      ];
       perSystem =
-        { system, pkgs, ... }:
+        { config, system, pkgs, ... }:
         {
+          overlayAttrs = {
+            inherit (config.packages) default;
+          };
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             # overlays = [


### PR DESCRIPTION
This PR adds an flake overlay for nix users to easily add talhelper into their own pkgs with an overlay 

For example in my nix dots:
```nix
nixosConfigurations = {
        ${user.hostname} = nixpkgs.lib.nixosSystem {
          specialArgs = {
            pkgs = import nixpkgs {
              overlays = [
                inputs.talhelper.overlays.default
              ];
              inherit system;
              config.allowUnfree = true;
            };
            inherit inputs system user;
          };
```

now I have access to pkgs.talhelper where I want to use or install it at.