### PR TITLE
fix(flake): Update package to be talhelper not default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         { config, system, pkgs, ... }:
         {
           overlayAttrs = {
-            inherit (config.packages) default;
+            inherit (config.packages) talhelper;
           };
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;


### PR DESCRIPTION
Fix. Mistakenly had default in the overlay which resulted in the package name being default so you would have to do pkgs.default to install talhelper instead of pkgs.talhelper. This fixes that.