### PR TITLE
feat(config): add `isoSchematic` for `genurl iso` if defined

### DIFF
--- a/cmd/genurl_iso.go
+++ b/cmd/genurl_iso.go
@@ -41,6 +41,10 @@ var genurlISOCmd = &cobra.Command{
 					schema = node.Schematic
 				}
 
+				if node.IsoSchematic != nil {
+					schema = node.IsoSchematic
+				}
+
 				if node.ContainsIP(genurlNode) || node.Hostname == genurlNode {
 					url, err := talos.GetISOURL(schema, cfg.GetImageFactory(), node.GetMachineSpec(), cfg.GetTalosVersion(), genurlOfflineMode)
 					if err != nil {

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -583,6 +583,24 @@ schematic:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`isoSchematic`</td>
+<td markdown="1">[Schematic](#schematic)</td>
+<td markdown="1">Configure Talos image customization to be used for ISO image<details><summary>*Show example*</summary>
+```yaml
+isoSchematic:
+  customization:
+    extraKernelArgs:
+      - net.ifnames=0
+    systemExtensions:
+      officialExtensions:
+        - siderolabs/intel-ucode
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`kernelModules`</td>
 <td markdown="1">[][KernelModuleConfig](#kernelmoduleconfig)</td>
 <td markdown="1">List of additional kernel modules to load.<details><summary>*Show example*</summary>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type NodeConfigs struct {
 	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
 	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
+	IsoSchematic        *schematic.Schematic           `yaml:"isoSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO image"`
 	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
 	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 	ExtensionServices   []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`


### PR DESCRIPTION
This allows having different image for ISO and installer

Fixes: https://github.com/budimanjojo/talhelper/issues/676
