### PR TITLE
feat(genurl)!: replace `genurl iso` subcommand with `genurl image`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -172,7 +172,7 @@ imageFactory:
   schematicEndpoint: /schematics
   protocol: https
   installerURLTmpl: {{.RegistryURL}}/installer/{{.ID}}:{{.Version}}
-  ISOURLTmpl: {{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}/{{.Arch}}.iso
+  ImageURLTmpl: {{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}/{{.Arch}}.iso
 ```
 </details></td>
 <td markdown="1" align="center">`nil`</td>
@@ -409,11 +409,13 @@ talosImageURL: factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d7
 <tr markdown="1">
 <td markdown="1">`machineSpec`</td>
 <td markdown="1">[MachineSpec](#machinespec)</td>
-<td markdown="1"><details><summary>Machine hardware specification for the node.</summary>Only used for `genurl iso` subcommand.</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>Machine hardware specification for the node.</summary>Only used for `genurl image` subcommand.</details><details><summary>*Show example*</summary>
 ```yaml
 machineSpec:
   mode: metal
   arch: arm64
+  bootMethod: disk-image
+  imageSuffix: raw.xz
 ```
 </summary></td>
 <td markdown="1" align="center">`nil`</td>
@@ -600,11 +602,11 @@ schematic:
 </tr>
 
 <tr markdown="1">
-<td markdown="1">`isoSchematic`</td>
+<td markdown="1">`imageSchematic`</td>
 <td markdown="1">[Schematic](#schematic)</td>
-<td markdown="1">Configure Talos image customization to be used for ISO image<details><summary>*Show example*</summary>
+<td markdown="1">Configure Talos image customization to be used for ISO or boot image<details><summary>*Show example*</summary>
 ```yaml
-isoSchematic:
+imageSchematic:
   customization:
     extraKernelArgs:
       - net.ifnames=0
@@ -762,14 +764,14 @@ installerURLTmpl: "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}"
 </tr>
 
 <tr markdown="1">
-<td markdown="1">`ISOURLTmpl`</td>
+<td markdown="1">`ImageURLTmpl`</td>
 <td markdown="1">string</td>
-<td markdown="1"><details><summary>Go template to parse the full ISO image URL.</summary>Available placeholders: `Protocol`,`RegistryURL`,`ID`,`Version`,`Mode`,`Arch`, `Secureboot`, `UseUKI`</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>Go template to parse the full ISO or boot image URL.</summary>Available placeholders: `Protocol`,`RegistryURL`,`ID`,`Version`,`Mode`,`Arch`, `Secureboot`, `UseUKI`, `BootMethod`, `Suffix`</details><details><summary>*Show example*</summary>
 ```yaml
-ISOURLTmpl: "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso"
+ImageURLTmpl: "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}.iso"
 ```
 </summary></td>
-<td markdown="1" align="center">`{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{else}}.iso{{end}}`</td>
+<td markdown="1" align="center">`{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{else}}{{.Suffix}}{{end}}`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 
@@ -829,6 +831,30 @@ useUKI: true
 ```
 </summary></td>
 <td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`bootMethod`</td>
+<td markdown="1">string</td>
+<td markdown="1"><details><summary>Boot method for the node.</summary>Can be "disk-image", "iso" or "pxe".</details><details><summary>*Show example*</summary>
+```yaml
+bootMethod: disk-image
+```
+</summary></td>
+<td markdown="1" align="center">`iso`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`imageSuffix`</td>
+<td markdown="1">string</td>
+<td markdown="1"><details><summary>The image file extension.</summary>Will be automatically defined by specified `bootMethod`, e.g: `raw.xz`, `raw.tar.gz`, `qcow2`.</details><details><summary>*Show example*</summary>
+```yaml
+imageSuffix: raw.xz
+```
+</summary></td>
+<td markdown="1" align="center">`""`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,14 +68,16 @@ type ImageFactory struct {
 	SchematicEndpoint string `yaml:"schematicEndpoint,omitempty" jsonschema:"default=/schematics,description:Endpoint to get schematic ID from the registry"`
 	Protocol          string `yaml:"protocol,omitempty" jsonschema:"default=https,description=Protocol of the registry(https or http)"`
 	InstallerURLTmpl  string `yaml:"installerURLTmpl,omitempty" jsonschema:"default={{.RegistryURL}}/installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}},description=Template for installer image URL"`
-	ISOURLTmpl        string `yaml:"ISOURLTmpl,omitempty" jsonschema:"default={{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{else}}.iso{{end}},description=Template for ISO image URL"`
+	ImageURLTmpl      string `yaml:"ISOURLTmpl,omitempty" jsonschema:"default={{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{else}}{{.Suffix}}{{end}},description=Template for image URL"`
 }
 
 type MachineSpec struct {
-	Mode       string `yaml:"mode,omitempty" jsonschema:"default=metal,description=Machine mode (e.g: metal)"`
-	Arch       string `yaml:"arch,omitempty" jsonschema:"default=amd64,description=Machine architecture (e.g: amd64, arm64)"`
-	Secureboot bool   `yaml:"secureboot,omitempty" jsonschema:"default=false,description=Whether to enable Secure Boot"`
-	UseUKI     bool   `yaml:"useUKI,omitempty" jsonschema:"default=false,description=Whether to use UKI if Secure Boot is enabled"`
+	Mode        string `yaml:"mode,omitempty" jsonschema:"default=metal,description=Machine mode (e.g: metal)"`
+	Arch        string `yaml:"arch,omitempty" jsonschema:"default=amd64,description=Machine architecture (e.g: amd64, arm64)"`
+	Secureboot  bool   `yaml:"secureboot,omitempty" jsonschema:"default=false,description=Whether to enable Secure Boot"`
+	UseUKI      bool   `yaml:"useUKI,omitempty" jsonschema:"default=false,description=Whether to use UKI if Secure Boot is enabled"`
+	BootMethod  string `yaml:"bootMethod,omitempty" jsonschema:"default=iso,description=Boot method of the node (can be disk-image, iso, or pxe)"`
+	ImageSuffix string `yaml:"imageSuffix,omitempty" jsonschema:"description=The image file extension (will be automatically determined by specified bootMethod) (e.g: raw.xz, raw.tar.gz, qcow2)"`
 }
 
 type IngressFirewall struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ type NodeConfigs struct {
 	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
 	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
-	IsoSchematic        *schematic.Schematic           `yaml:"isoSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO image"`
+	ImageSchematic      *schematic.Schematic           `yaml:"imageSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO or boot image"`
 	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
 	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 	ExtensionServices   []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -79,7 +79,7 @@ func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
 		SchematicEndpoint: "/schematics",
 		Protocol:          "https",
 		InstallerURLTmpl:  "{{.RegistryURL}}/installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}}",
-		ISOURLTmpl:        "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{else}}.iso{{end}}",
+		ImageURLTmpl:      "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{ else }}{{.Suffix}}{{end}}",
 	}
 	if c.ImageFactory.RegistryURL != "" {
 		result.RegistryURL = c.ImageFactory.RegistryURL
@@ -93,20 +93,31 @@ func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
 	if c.ImageFactory.InstallerURLTmpl != "" {
 		result.InstallerURLTmpl = c.ImageFactory.InstallerURLTmpl
 	}
+	if c.ImageFactory.ImageURLTmpl != "" {
+		result.ImageURLTmpl = c.ImageFactory.ImageURLTmpl
+	}
 	return result
 }
 
 // GetMachineSpec returns default `MachineSpec` for `Node` if not specified.
 func (n *Node) GetMachineSpec() *MachineSpec {
 	result := &MachineSpec{
-		Mode: "metal",
-		Arch: "amd64",
+		Mode:        "metal",
+		Arch:        "amd64",
+		BootMethod:  "iso",
+		ImageSuffix: "iso",
+	}
+	if n.MachineSpec.BootMethod != "" {
+		result.BootMethod = n.MachineSpec.BootMethod
 	}
 	if n.MachineSpec.Mode != "" {
 		result.Mode = n.MachineSpec.Mode
 	}
 	if n.MachineSpec.Arch != "" {
 		result.Arch = n.MachineSpec.Arch
+	}
+	if n.MachineSpec.ImageSuffix != "" {
+		result.ImageSuffix = n.MachineSpec.ImageSuffix
 	}
 	result.Secureboot = n.MachineSpec.Secureboot
 	result.UseUKI = n.MachineSpec.UseUKI

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -64,6 +64,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		}
 		checkNodeNameServers(node, k, &result)
 		checkNodeNetworkInterfaces(node, k, &result)
+		checkNodeMachineSpec(node, k, &result)
 		checkNodeIngressFirewall(node, k, &result)
 		checkNodeExtraManifests(node, k, &result)
 	}


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/790

BREAKING CHANGE: Before this change, `talhelper genurl iso` will generate this:
`https://factory.talos.dev/image/<id>/<version>/<mode>-<arch>.iso`

Now you can do the same with `talhelper genurl image`

In addition to ISO images, you can also generate disk and PXE images.
For example, to generate disk-image with default raw.zst extension you can do:
`talhelper genurl image --boot-method disk-image`
and it will output:
`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.9.1/metal-amd64.raw.zst`

If you want to generate url for node inside `talconfig.yaml` you can have something like this (i.e for Pine64 SBC):
```yaml
nodes:
  - hostname: kmaster1
    schematics:
      customization: {}
      overlay:
        name: pine64
        image: siderolabs/sbc-allwinner
    machineSpec:
      arch: arm64
      bootMethod: disk-image
      imageSuffix: raw.xz
```

Then, in the same directory with your `talconfig.yaml` file, run:
`talhelper genurl image -n kmaster1` and you'll get: `https://factory.talos.dev/image/185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175/v1.9.1/metal-arm64.raw.xz`
