### PR TITLE
add `inlineManifests` and add feature to `machineFiles`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -202,6 +202,24 @@ patches:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`inlineManifests`</td>
+<td markdown="1">[][InlineManifest](#inlinemanifest)</td>
+<td markdown="1">A list of inline Kubernetes manifests for the cluster.</details><details><summary>*Show example*</summary>
+```yaml
+inlineManifests:
+  - name: namespace-ci
+    contents: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: ci
+```
+</details></td>
+<td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`controlPlane`</td>
 <td markdown="1">[NodeConfigs](#nodeconfigs)</td>
 <td markdown="1">Configurations targetted for all controlplane nodes.</details><details><summary>*Show example*</summary>
@@ -1050,6 +1068,12 @@ ingress:
 ## InstallDiskSelector
 
 `InstallDiskSelector` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/#installdiskselector" target="_blank">`v1alpha1.InstallDiskSelector`</a>.
+
+## InlineManifest
+
+`InlineManifest` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/v1alpha1/config/#Config.cluster.inlineManifests." target="_blank">`v1alpha1.ClusterInlineManifest`</a>
+
+In addition to this, there's also a `skipEnvsubst` key that can be set to `true` to skip doing envsubst (only for file outside of `talconfig.yaml`)
 
 ## MachineDisk
 

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -1059,6 +1059,8 @@ ingress:
 
 `MachineFile` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/#machinefile" target="_blank">`v1alpha1.MachineFile`</a>
 
+In addition to this, there's also a `skipEnvsubst` key that can be set to `true` to skip doing envsubst (only for file outside of `talconfig.yaml`)
+
 ## InstallExtensionConfig
 
 `InstallExtensionConfig` is type of upstream Talos <a href="https://www.talos.dev/latest/reference/configuration/#installextensionconfig" target="_blank">`v1alpha1.InstallExtensionConfig`</a>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ type NodeConfigs struct {
 	NodeAnnotations     map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
 	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
 	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
-	MachineFiles        []*v1alpha1.MachineFile        `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	MachineFiles        MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
 	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
 	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
 	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
@@ -100,4 +100,11 @@ type ExtensionService struct {
 type Volume struct {
 	Name         string                 `yaml:"name" jsonschema:"description=Name of the volume config"`
 	Provisioning block.ProvisioningSpec `yaml:"provisioning" jsonschema:"description=Provisioning spec of the volume config"`
+}
+
+type MachineFiles []*MachineFile
+
+type MachineFile struct {
+	v1alpha1.MachineFile `yaml:",inline"`
+	SkipEnvsubst         bool `yaml:"skipEnvsubst" jsonschema:"description=Whether to skip envsubst to the contents (only for contents in another file)"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,23 +10,24 @@ import (
 )
 
 type TalhelperConfig struct {
-	ClusterName                    string              `yaml:"clusterName" jsonschema:"required,description=Name of the cluster"`
-	TalosVersion                   string              `yaml:"talosVersion,omitempty" jsonschema:"example=v1.5.4,description=Talos version to perform installation"`
-	KubernetesVersion              string              `yaml:"kubernetesVersion,omitempty" jsonschema:"example=v1.27.0,description=Kubernetes version to use"`
-	Endpoint                       string              `yaml:"endpoint" jsonschema:"required,example=https://192.168.200.10:6443,description=Cluster's controlplane endpoint"`
-	Domain                         string              `yaml:"domain,omitempty" jsonschema:"example=cluster.local,description=The domain to be used by Kubernetes DNS"`
-	AllowSchedulingOnMasters       bool                `yaml:"allowSchedulingOnMasters,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes"`
-	AllowSchedulingOnControlPlanes bool                `yaml:"allowSchedulingOnControlPlanes,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes. It is an alias to \"AllowSchedulingOnMasters\""`
-	AdditionalMachineCertSans      []string            `yaml:"additionalMachineCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the machine's certificate"`
-	AdditionalApiServerCertSans    []string            `yaml:"additionalApiServerCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the API server's certificate"`
-	ClusterPodNets                 []string            `yaml:"clusterPodNets,omitempty" jsonschema:"description=The pod subnet CIDR list"`
-	ClusterSvcNets                 []string            `yaml:"clusterSvcNets,omitempty" jsonschema:"description=The service subnet CIDR list"`
-	CNIConfig                      *v1alpha1.CNIConfig `yaml:"cniConfig,omitempty" jsonschema:"description=The CNI to be used for the cluster's network"`
-	Patches                        []string            `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all nodes"`
-	Nodes                          []Node              `yaml:"nodes" jsonschema:"required,description=List of configurations for Node"`
-	ImageFactory                   ImageFactory        `yaml:"imageFactory,omitempty" jsonschema:"Configuration for image factory"`
-	ControlPlane                   NodeConfigs         `yaml:"controlPlane,omitempty" jsonschema:"description=Configurations targetted for all controlplane nodes"`
-	Worker                         NodeConfigs         `yaml:"worker,omitempty" jsonschema:"description=Configurations targetted for all worker nodes"`
+	ClusterName                    string                 `yaml:"clusterName" jsonschema:"required,description=Name of the cluster"`
+	TalosVersion                   string                 `yaml:"talosVersion,omitempty" jsonschema:"example=v1.5.4,description=Talos version to perform installation"`
+	KubernetesVersion              string                 `yaml:"kubernetesVersion,omitempty" jsonschema:"example=v1.27.0,description=Kubernetes version to use"`
+	Endpoint                       string                 `yaml:"endpoint" jsonschema:"required,example=https://192.168.200.10:6443,description=Cluster's controlplane endpoint"`
+	Domain                         string                 `yaml:"domain,omitempty" jsonschema:"example=cluster.local,description=The domain to be used by Kubernetes DNS"`
+	AllowSchedulingOnMasters       bool                   `yaml:"allowSchedulingOnMasters,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes"`
+	AllowSchedulingOnControlPlanes bool                   `yaml:"allowSchedulingOnControlPlanes,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes. It is an alias to \"AllowSchedulingOnMasters\""`
+	AdditionalMachineCertSans      []string               `yaml:"additionalMachineCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the machine's certificate"`
+	AdditionalApiServerCertSans    []string               `yaml:"additionalApiServerCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the API server's certificate"`
+	ClusterInlineManifests         ClusterInlineManifests `yaml:"inlineManifests,omitempty" jsonschema:"description=A list of inline Kubernetes manifests for the cluster"`
+	ClusterPodNets                 []string               `yaml:"clusterPodNets,omitempty" jsonschema:"description=The pod subnet CIDR list"`
+	ClusterSvcNets                 []string               `yaml:"clusterSvcNets,omitempty" jsonschema:"description=The service subnet CIDR list"`
+	CNIConfig                      *v1alpha1.CNIConfig    `yaml:"cniConfig,omitempty" jsonschema:"description=The CNI to be used for the cluster's network"`
+	Patches                        []string               `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to all nodes"`
+	Nodes                          []Node                 `yaml:"nodes" jsonschema:"required,description=List of configurations for Node"`
+	ImageFactory                   ImageFactory           `yaml:"imageFactory,omitempty" jsonschema:"Configuration for image factory"`
+	ControlPlane                   NodeConfigs            `yaml:"controlPlane,omitempty" jsonschema:"description=Configurations targetted for all controlplane nodes"`
+	Worker                         NodeConfigs            `yaml:"worker,omitempty" jsonschema:"description=Configurations targetted for all worker nodes"`
 }
 
 type Node struct {
@@ -107,4 +108,11 @@ type MachineFiles []*MachineFile
 type MachineFile struct {
 	v1alpha1.MachineFile `yaml:",inline"`
 	SkipEnvsubst         bool `yaml:"skipEnvsubst" jsonschema:"description=Whether to skip envsubst to the contents (only for contents in another file)"`
+}
+
+type ClusterInlineManifests []*ClusterInlineManifest
+
+type ClusterInlineManifest struct {
+	v1alpha1.ClusterInlineManifest `yaml:",inline"`
+	SkipEnvsubst                   bool `yaml:"skipEnvsubst" jsonschema:"description=Whether to skip envsubst to the contents (only for contents in another file)"`
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/budimanjojo/talhelper/v3/pkg/substitute"
 	"github.com/fatih/color"
@@ -58,7 +57,7 @@ func LoadAndValidateFromFile(filePath string, envPaths []string, showWarns bool)
 
 		if len(node.MachineFiles) > 0 {
 			for i, file := range node.MachineFiles {
-				contents, err := ensureFileContent(file.FileContent)
+				contents, err := substitute.SubstituteFileContent(file.FileContent, !file.SkipEnvsubst)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get machine file content for %s in `machineFiles[%d]`: %s", node.Hostname, i, err)
 				}
@@ -132,25 +131,4 @@ func newConfig(source []byte) (c *TalhelperConfig, err error) {
 		return nil, err
 	}
 	return c, nil
-}
-
-func ensureFileContent(value string) (string, error) {
-	if strings.HasPrefix(value, "@") {
-		slog.Debug(fmt.Sprintf("getting file content of %s", value))
-		filename := value[1:]
-
-		contents, err := os.ReadFile(filename)
-		if err != nil {
-			return "", err
-		}
-
-		substituted, err := substitute.SubstituteEnvFromByte(contents)
-		if err != nil {
-			return "", err
-		}
-
-		return string(substituted), nil
-	}
-
-	return value, nil
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -43,6 +43,16 @@ func LoadAndValidateFromFile(filePath string, envPaths []string, showWarns bool)
 		return nil, fmt.Errorf("failed to unmarshal config file: %s", err)
 	}
 
+	if len(cfg.ClusterInlineManifests) > 0 {
+		for i, manifest := range cfg.ClusterInlineManifests {
+			contents, err := substitute.SubstituteFileContent(manifest.InlineManifestContents, !manifest.SkipEnvsubst)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get inlineManifest content for %s in `inlineManifest[%d]`: %s", manifest.InlineManifestContents, i, err)
+			}
+			manifest.InlineManifestContents = contents
+		}
+	}
+
 	for k := range cfg.Nodes {
 		node := &cfg.Nodes[k]
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -47,6 +47,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 	checkDomain(c, &result)
 	checkClusterNets(c, &result)
 	checkCNIConfig(c, &result)
+	checkClusterInlineManifests(c, &result)
 	for k, node := range c.Nodes {
 		slog.Debug(fmt.Sprintf("validating config file for node %s", node.Hostname))
 		checkNodeRequiredCfg(node, k, &result)

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -216,6 +216,25 @@ func checkCNIConfig(c TalhelperConfig, result *Errors) *Errors {
 	return result
 }
 
+func checkClusterInlineManifests(c TalhelperConfig, result *Errors) *Errors {
+	if c.ClusterInlineManifests != nil {
+		var messages *multierror.Error
+
+		cims := c.ClusterInlineManifests.GetIMs()
+		err := cims.Validate()
+		messages = multierror.Append(messages, err)
+
+		if messages.ErrorOrNil() != nil {
+			return result.Append(&Error{
+				Kind:    "InvalidClusterInlineManifests",
+				Field:   getFieldYamlTag(c, "inlineManifests"),
+				Message: formatError(messages),
+			})
+		}
+	}
+	return result
+}
+
 func checkNodeRequiredCfg(node Node, idx int, result *Errors) *Errors {
 	if node.Hostname == "" {
 		e := &Error{

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -371,11 +371,12 @@ func checkNodeMachineDisks(node Node, idx int, result *Errors) *Errors {
 
 func checkNodeMachineFiles(node Node, idx int, result *Errors) *Errors {
 	if node.MachineFiles != nil {
+		mfs := node.MachineFiles.GetMFs()
 		var messages *multierror.Error
 		pattern := `^create$|^append$|^overwrite$`
 		re := regexp.MustCompile(pattern)
 
-		for _, file := range node.MachineFiles {
+		for _, file := range mfs {
 			if !re.MatchString(file.FileOp) {
 				messages = multierror.Append(messages, fmt.Errorf("%q is not a valid operation name (create,append,overwrite)", file.Op()))
 			}

--- a/pkg/config/wrapper.go
+++ b/pkg/config/wrapper.go
@@ -12,3 +12,12 @@ func (mfs MachineFiles) GetMFs() []*v1alpha1.MachineFile {
 	}
 	return result
 }
+
+func (cims ClusterInlineManifests) GetIMs() *v1alpha1.ClusterInlineManifests {
+	result := make(v1alpha1.ClusterInlineManifests, 0, len(cims))
+
+	for _, im := range cims {
+		result = append(result, im.ClusterInlineManifest)
+	}
+	return &result
+}

--- a/pkg/config/wrapper.go
+++ b/pkg/config/wrapper.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+)
+
+func (mfs MachineFiles) GetMFs() []*v1alpha1.MachineFile {
+	result := make([]*v1alpha1.MachineFile, 0, len(mfs))
+
+	for _, mf := range mfs {
+		result = append(result, &mf.MachineFile)
+	}
+	return result
+}

--- a/pkg/substitute/contentsubst.go
+++ b/pkg/substitute/contentsubst.go
@@ -1,0 +1,36 @@
+package substitute
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// SubstituteFileContent will read and return the content of a file if `value` is string prefixed with `@`
+// followed by a path. Otherwise the value will be returned as it is.
+// The content will also be envsubst-ed if `envsubst` is `true`.
+// It will also returns an error, if any.
+func SubstituteFileContent(value string, envsubst bool) (string, error) {
+	if strings.HasPrefix(value, "@") {
+		slog.Debug(fmt.Sprintf("getting file content of %s", value))
+		filename := value[1:]
+
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return "", err
+		}
+
+		if envsubst {
+			substituted, err := SubstituteEnvFromByte(contents)
+			if err != nil {
+				return "", err
+			}
+			return string(substituted), nil
+		}
+
+		return string(contents), nil
+	}
+
+	return value, nil
+}

--- a/pkg/substitute/contentsubst_test.go
+++ b/pkg/substitute/contentsubst_test.go
@@ -1,0 +1,69 @@
+package substitute
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSubstituteFileContent(t *testing.T) {
+	contents := []string{
+		"@./testdata/content.yaml",
+		"this is $host",
+	}
+	envs := map[string]string{
+		"host":           "substhost",
+		"remote_addr":    "substremote_addr",
+		"request_method": "substrequest_method",
+		"uri":            "substuri",
+	}
+
+	for env, value := range envs {
+		os.Setenv(env, value)
+	}
+
+	expectedWithoutEnvsubst := []string{
+		`---
+# Source: cilium/templates/hubble-ui/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+  namespace: kube-system
+data:
+  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            # double ` + "`" + "/index.html" + "`" + ` is required here \n            try_files $uri $uri/ /index.html /index.html;\n        }\n\n        # Liveness probe\n        location /healthz {\n            access_log off;\n            add_header Content-Type text/plain;\n            return 200 'ok';\n        }\n    }\n}"
+---`,
+		"this is $host",
+	}
+
+	expectedWithEnvsubst := []string{
+		`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+  namespace: kube-system
+data:
+  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host substhost;\n        proxy_set_header X-Real-IP substremote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if (substrequest_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            # double ` + "`" + "/index.html" + "`" + ` is required here \n            try_files substuri substuri/ /index.html /index.html;\n        }\n\n        # Liveness probe\n        location /healthz {\n            access_log off;\n            add_header Content-Type text/plain;\n            return 200 'ok';\n        }\n    }\n}"
+---`, // header and comments are removed by SubstituteEnvFromByte()
+		"this is $host", // ignored when it's not a file
+	}
+
+	for k, v := range contents {
+		r1, err := SubstituteFileContent(v, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expectedWithoutEnvsubst[k] != strings.TrimSpace(r1) {
+			t.Errorf("got\n%s,\bwant\n%s", strings.TrimSpace(r1), expectedWithoutEnvsubst[k])
+		}
+
+		r2, err := SubstituteFileContent(v, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if expectedWithEnvsubst[k] != strings.TrimSpace(r2) {
+			t.Errorf("got\n%s,\bwant\n%s", strings.TrimSpace(r2), expectedWithEnvsubst[k])
+		}
+	}
+}

--- a/pkg/substitute/pathsubst.go
+++ b/pkg/substitute/pathsubst.go
@@ -77,7 +77,7 @@ func processNode(node interface{}, path []string, yamlDir string) interface{} {
 
 func shouldSubstitute(path []string) bool {
 	for _, p := range path {
-		if p == "machineFiles" || p == "patches" || p == "extraManifests" {
+		if p == "machineFiles" || p == "patches" || p == "extraManifests" || p == "inlineManifests" {
 			return true
 		}
 	}

--- a/pkg/substitute/testdata/content.yaml
+++ b/pkg/substitute/testdata/content.yaml
@@ -1,0 +1,10 @@
+---
+# Source: cilium/templates/hubble-ui/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+  namespace: kube-system
+data:
+  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n        location / {\n            # double `/index.html` is required here \n            try_files $uri $uri/ /index.html /index.html;\n        }\n\n        # Liveness probe\n        location /healthz {\n            access_log off;\n            add_header Content-Type text/plain;\n            return 200 'ok';\n        }\n    }\n}"
+---

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -125,7 +125,7 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 
 	if len(node.MachineFiles) > 0 {
 		slog.Debug("setting machine files")
-		cfg.RawV1Alpha1().MachineConfig.MachineFiles = node.MachineFiles
+		cfg.RawV1Alpha1().MachineConfig.MachineFiles = node.MachineFiles.GetMFs()
 	}
 
 	if node.Schematic != nil && len(node.Schematic.Customization.ExtraKernelArgs) > 0 {


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/833

- **feat(config): allow `machineFiles` to be not envsubst-ed**

Now, you can have something like this so the content is not being env
substituted by `talhelper`:
```yaml
nodes:
  - machineFiles:
      - content: "@./a-file-outside-of-config"
        permission: 0o644
        path: /path/inside/node
        op: create
        skipEnvsubst: true
```

Note that this only works for file outside of `talconfig.yaml` like
shown in the example above because `talhelper` will do envsubst to the
entire config file and there's no easy way to change that.

- **feat(config): add `inlineManifests`**

Just like `machineFiles`, you can tell `talhelper` to skip env
substituting the content of the manifest like so:
```yaml
inlineManifests:
  - name: cilium
    contents: "@./cilium-manifests-in-another-file.yaml"
    skipEnvsubst: true
```

Note that this only works for file outside of `talconfig.yaml` like
shown in the example above because `talhelper` will do envsubst to the
entire config file and there's no easy way to change that.

- **feat(code): add test for content substitution**
