### PR TITLE
Swap kubectl Install Image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 ## ================================================================================================
 # Utility versions
 ## ================================================================================================
-ARG KUBECTL_VERSION=1.32.1
+ARG KUBECTL_VERSION=v1.32.1
 ARG TALOSCTL_VERSION=v1.9.3
 ARG GOLINT_VERSION=v1.64.2-alpine
 ARG GORELEASER_VERSION=v2.7.0
@@ -10,7 +10,7 @@ ARG AGE_VERSION=v1.2.0
 ARG AGE_KEYGEN_VERSION=V1.2.0
 
 
-FROM bitnami/kubectl:${KUBECTL_VERSION} AS kubectl
+FROM registry.k8s.io/kubectl:${KUBECTL_VERSION} AS kubectl
 FROM ghcr.io/siderolabs/talosctl:${TALOSCTL_VERSION} AS talosctl
 FROM golangci/golangci-lint:${GOLINT_VERSION} AS golangci-lint
 FROM goreleaser/goreleaser:${GORELEASER_VERSION} AS goreleaser

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ FROM ghcr.io/mirceanton/age-keygen:${AGE_KEYGEN_VERSION} AS age-keygen
 ## ================================================================================================
 FROM mcr.microsoft.com/devcontainers/go:1.23-bookworm@sha256:a417a341a2a8648db7bf8527b86364848362a2c8dc150993c8a4cc2b53b4ec47 AS workspace
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
 COPY --from=talosctl /talosctl /usr/local/bin/talosctl
 COPY --from=golangci-lint /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 COPY --from=goreleaser /usr/bin/goreleaser /usr/local/bin/goreleaser


### PR DESCRIPTION
This PR swaps the kubectl binary from bitnami/kubectl to registry.k8s.io/kubectl, also updates the binary copy location.