### PR TITLE
feat(config): add node `certSANs` and deprecate `additionalMachineCertSans`

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -384,11 +384,11 @@ overrideExtraManifests: true
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 <tr markdown="1">
-<td markdown="1">`overrideExtraCertSANs`</td>
+<td markdown="1">`overrideMachineCertSANs`</td>
 <td markdown="1">bool</td>
-<td markdown="1"><details><summary>Whether `extraCertSANs` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>Whether `certSANs` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
 ```yaml
-overrideExtraCertSANs: true
+overrideMachineCertSANs: true
 ```
 </summary></td>
 <td markdown="1" align="center">`false`</td>
@@ -711,11 +711,11 @@ extraManifests:
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 <tr markdown="1">
-<td markdown="1">`extraCertSANs`</td>
+<td markdown="1">`certSANs`</td>
 <td markdown="1">[]string</td>
 <td markdown="1">Extra SANs in the machine's certificate.<details><summary>*Show example*</summary>
 ```yaml
-extraCertSANs:
+certSANs:
   - example.org
   - 172.16.0.10
   - 192.168.0.10

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -120,7 +120,7 @@ allowSchedulingOnControlPlanes: true
 <tr markdown="1">
 <td markdown="1">`additionalMachineCertSans`</td>
 <td markdown="1">[]string</td>
-<td markdown="1">Extra certificate SANs for the machine's certificate.<details><summary>*Show example*</summary>
+<td markdown="1">**DEPRECATED! Use node/node groups `extraMachineCertSans`**. Extra certificate SANs for the machine's certificate.<details><summary>*Show example*</summary>
 ```yaml
 additionalMachineCertSans:
   - 10.0.0.10
@@ -696,6 +696,20 @@ extraManifests:
   - kubelet-firewall.yaml
 ```
 </summary></td>
+<td markdown="1" align="center">`[]`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+<tr markdown="1">
+<td markdown="1">`extraMachineCertSans`</td>
+<td markdown="1">[]string</td>
+<td markdown="1">Extra SANs in the machine's certificate.<details><summary>*Show example*</summary>
+```yaml
+extraMachineCertSans:
+  - example.org
+  - 172.16.0.10
+  - 192.168.0.10
+```
+</details></td>
 <td markdown="1" align="center">`[]`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -383,6 +383,17 @@ overrideExtraManifests: true
 <td markdown="1" align="center">`false`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
+<tr markdown="1">
+<td markdown="1">`overrideExtraMachineCertSans`</td>
+<td markdown="1">bool</td>
+<td markdown="1"><details><summary>Whether `extraMachineCertSans` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
+```yaml
+overrideExtraMachineCertSans: true
+```
+</summary></td>
+<td markdown="1" align="center">`false`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
 
 <tr markdown="1">
 <td markdown="1">-</td>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -384,11 +384,11 @@ overrideExtraManifests: true
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 <tr markdown="1">
-<td markdown="1">`overrideExtraMachineCertSans`</td>
+<td markdown="1">`overrideExtraCertSANs`</td>
 <td markdown="1">bool</td>
-<td markdown="1"><details><summary>Whether `extraMachineCertSans` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>Whether `extraCertSANs` defined here should override the one defined in node group.</summary>By default they will get appended instead.</details><details><summary>*Show example*</summary>
 ```yaml
-overrideExtraMachineCertSans: true
+overrideExtraCertSANs: true
 ```
 </summary></td>
 <td markdown="1" align="center">`false`</td>
@@ -711,11 +711,11 @@ extraManifests:
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 <tr markdown="1">
-<td markdown="1">`extraMachineCertSans`</td>
+<td markdown="1">`extraCertSANs`</td>
 <td markdown="1">[]string</td>
 <td markdown="1">Extra SANs in the machine's certificate.<details><summary>*Show example*</summary>
 ```yaml
-extraMachineCertSans:
+extraCertSANs:
   - example.org
   - 172.16.0.10
   - 192.168.0.10

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,16 +31,16 @@ type TalhelperConfig struct {
 }
 
 type Node struct {
-	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
-	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
-	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
-	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	OverrideExtraCertSANs  bool                          `yaml:"overrideExtraCertSANs,omitempty" jsonschema:"description=Whether \"extraCertSANs\" defined here should override the one defined in node group"`
-	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
+	Hostname                string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress               string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
+	ControlPlane            bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk             string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector     *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname          bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
+	OverridePatches         bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests  bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	OverrideMachineCertSANs bool                          `yaml:"overrideMachineCertSANs,omitempty" jsonschema:"description=Whether \"certSANs\" defined here should override the one defined in node group"`
+	NodeConfigs             `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
 type NodeConfigs struct {
@@ -54,7 +54,7 @@ type NodeConfigs struct {
 	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
 	NetworkInterfaces   []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
 	ExtraManifests      []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
-	ExtraCertSANs       []string                       `yaml:"extraCertSANs,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
+	CertSANs            []string                       `yaml:"certSANs,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
 	Patches             []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
 	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,15 +31,16 @@ type TalhelperConfig struct {
 }
 
 type Node struct {
-	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
-	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
-	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
-	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
+	Hostname                     string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress                    string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
+	ControlPlane                 bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk                  string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector          *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname               bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
+	OverridePatches              bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests       bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	OverrideExtraMachineCertSans bool                          `yaml:"OverrideExtraMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMaachineCertSans\" defined here should override the one defined in node group"`
+	NodeConfigs                  `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
 type NodeConfigs struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,7 @@ type Node struct {
 	IgnoreHostname               bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
 	OverridePatches              bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
 	OverrideExtraManifests       bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	OverrideExtraMachineCertSans bool                          `yaml:"OverrideExtraMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMaachineCertSans\" defined here should override the one defined in node group"`
+	OverrideExtraMachineCertSans bool                          `yaml:"overrideExtraMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMaachineCertSans\" defined here should override the one defined in node group"`
 	NodeConfigs                  `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ type TalhelperConfig struct {
 	Domain                         string                 `yaml:"domain,omitempty" jsonschema:"example=cluster.local,description=The domain to be used by Kubernetes DNS"`
 	AllowSchedulingOnMasters       bool                   `yaml:"allowSchedulingOnMasters,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes"`
 	AllowSchedulingOnControlPlanes bool                   `yaml:"allowSchedulingOnControlPlanes,omitempty" jsonschema:"description=Whether to allow running workload on controlplane nodes. It is an alias to \"AllowSchedulingOnMasters\""`
-	AdditionalMachineCertSans      []string               `yaml:"additionalMachineCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the machine's certificate"`
+	AdditionalMachineCertSans      []string               `yaml:"additionalMachineCertSans,omitempty" jsonschema:"description=DEPRECATED Use node/node groups extraMachineCertSans ! Extra certificate SANs for the machine's certificate"`
 	AdditionalApiServerCertSans    []string               `yaml:"additionalApiServerCertSans,omitempty" jsonschema:"description=Extra certificate SANs for the API server's certificate"`
 	ClusterInlineManifests         ClusterInlineManifests `yaml:"inlineManifests,omitempty" jsonschema:"description=A list of inline Kubernetes manifests for the cluster"`
 	ClusterPodNets                 []string               `yaml:"clusterPodNets,omitempty" jsonschema:"description=The pod subnet CIDR list"`
@@ -31,37 +31,39 @@ type TalhelperConfig struct {
 }
 
 type Node struct {
-	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
-	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
-	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
-	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
+	Hostname                string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress               string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
+	ControlPlane            bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk             string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector     *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname          bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
+	OverridePatches         bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests  bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	OverrideMachineCertSans bool                          `yaml:"overrideMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMachineCertSans\" defined here should override the one defined in node group"`
+	NodeConfigs             `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
 type NodeConfigs struct {
-	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
-	NodeAnnotations     map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
-	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
-	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
-	MachineFiles        MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
-	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
-	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
-	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
-	NetworkInterfaces   []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
-	ExtraManifests      []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
-	Patches             []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
-	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
-	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
-	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
-	ImageSchematic      *schematic.Schematic           `yaml:"imageSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO or boot image"`
-	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
-	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
-	ExtensionServices   []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`
-	Volumes             []*Volume                      `yaml:"volumes,omitempty" jsonschema:"description=Machine volume configs specification"`
+	ExtraMachineCertSans []string                       `yaml:"extraMachineCertSans,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
+	NodeLabels           map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
+	NodeAnnotations      map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
+	NodeTaints           map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
+	MachineDisks         []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
+	MachineFiles         MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	DisableSearchDomain  bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
+	KernelModules        []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
+	Nameservers          []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
+	NetworkInterfaces    []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
+	ExtraManifests       []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
+	Patches              []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
+	TalosImageURL        string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
+	NoSchematicValidate  bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
+	Schematic            *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
+	ImageSchematic       *schematic.Schematic           `yaml:"imageSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO or boot image"`
+	MachineSpec          MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
+	IngressFirewall      *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
+	ExtensionServices    []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`
+	Volumes              []*Volume                      `yaml:"volumes,omitempty" jsonschema:"description=Machine volume configs specification"`
 }
 
 type ImageFactory struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,39 +31,39 @@ type TalhelperConfig struct {
 }
 
 type Node struct {
-	Hostname                     string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress                    string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
-	ControlPlane                 bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	InstallDisk                  string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector          *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	IgnoreHostname               bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
-	OverridePatches              bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
-	OverrideExtraManifests       bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	OverrideExtraMachineCertSans bool                          `yaml:"overrideExtraMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMaachineCertSans\" defined here should override the one defined in node group"`
-	NodeConfigs                  `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
+	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
+	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
+	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	OverrideExtraCertSANs  bool                          `yaml:"overrideExtraCertSANs,omitempty" jsonschema:"description=Whether \"extraCertSANs\" defined here should override the one defined in node group"`
+	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
 type NodeConfigs struct {
-	NodeLabels           map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
-	NodeAnnotations      map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
-	NodeTaints           map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
-	MachineDisks         []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
-	MachineFiles         MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
-	DisableSearchDomain  bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
-	KernelModules        []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
-	Nameservers          []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
-	NetworkInterfaces    []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
-	ExtraManifests       []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
-	ExtraMachineCertSans []string                       `yaml:"extraMachineCertSans,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
-	Patches              []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
-	TalosImageURL        string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
-	NoSchematicValidate  bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
-	Schematic            *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
-	ImageSchematic       *schematic.Schematic           `yaml:"imageSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO or boot image"`
-	MachineSpec          MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
-	IngressFirewall      *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
-	ExtensionServices    []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`
-	Volumes              []*Volume                      `yaml:"volumes,omitempty" jsonschema:"description=Machine volume configs specification"`
+	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
+	NodeAnnotations     map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
+	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
+	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
+	MachineFiles        MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
+	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
+	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`
+	Nameservers         []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
+	NetworkInterfaces   []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
+	ExtraManifests      []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
+	ExtraCertSANs       []string                       `yaml:"extraCertSANs,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
+	Patches             []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
+	TalosImageURL       string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
+	NoSchematicValidate bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`
+	Schematic           *schematic.Schematic           `yaml:"schematic,omitempty" jsonschema:"description=Talos image customization to be used in the installer image"`
+	ImageSchematic      *schematic.Schematic           `yaml:"imageSchematic,omitempty" jsonschema:"description=Talos image customization to be used for ISO or boot image"`
+	MachineSpec         MachineSpec                    `yaml:"machineSpec,omitempty" jsonschema:"description=Machine hardware specification"`
+	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
+	ExtensionServices   []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`
+	Volumes             []*Volume                      `yaml:"volumes,omitempty" jsonschema:"description=Machine volume configs specification"`
 }
 
 type ImageFactory struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,20 +31,18 @@ type TalhelperConfig struct {
 }
 
 type Node struct {
-	Hostname                string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
-	IPAddress               string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
-	ControlPlane            bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
-	InstallDisk             string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
-	InstallDiskSelector     *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
-	IgnoreHostname          bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
-	OverridePatches         bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
-	OverrideExtraManifests  bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
-	OverrideMachineCertSans bool                          `yaml:"overrideMachineCertSans,omitempty" jsonschema:"description=Whether \"extraMachineCertSans\" defined here should override the one defined in node group"`
-	NodeConfigs             `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
+	Hostname               string                        `yaml:"hostname" jsonschema:"required,description=Hostname of the node"`
+	IPAddress              string                        `yaml:"ipAddress,omitempty" jsonschema:"required,example=192.168.200.11,description=IP address where the node can be reached, can also be a comma separated IP addresses"`
+	ControlPlane           bool                          `yaml:"controlPlane" jsonschema:"description=Whether the node is a controlplane"`
+	InstallDisk            string                        `yaml:"installDisk,omitempty" jsonschema:"oneof_required=installDiskSelector,description=The disk used for installation"`
+	InstallDiskSelector    *v1alpha1.InstallDiskSelector `yaml:"installDiskSelector,omitempty" jsonschema:"oneof_required=installDisk,description=Look up disk used for installation"`
+	IgnoreHostname         bool                          `yaml:"ignoreHostname" jsonschema:"description=Whether to set \"machine.network.hostname\" to the generated config file"`
+	OverridePatches        bool                          `yaml:"overridePatches,omitempty" jsonschema:"description=Whether \"patches\" defined here should override the one defined in node group"`
+	OverrideExtraManifests bool                          `yaml:"overrideExtraManifests,omitempty" jsonschema:"description=Whether \"extraManifests\" defined here should override the one defined in node group"`
+	NodeConfigs            `yaml:",inline" jsonschema:"description=Node specific configurations that will override node group configurations"`
 }
 
 type NodeConfigs struct {
-	ExtraMachineCertSans []string                       `yaml:"extraMachineCertSans,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
 	NodeLabels           map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
 	NodeAnnotations      map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
 	NodeTaints           map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
@@ -55,6 +53,7 @@ type NodeConfigs struct {
 	Nameservers          []string                       `yaml:"nameservers,omitempty" jsonschema:"description=List of nameservers for the node"`
 	NetworkInterfaces    []*v1alpha1.Device             `yaml:"networkInterfaces,omitempty" jsonschema:"description=List of network interface configuration for the node"`
 	ExtraManifests       []string                       `yaml:"extraManifests,omitempty" jsonschema:"description=List of manifest files to be added to the node"`
+	ExtraMachineCertSans []string                       `yaml:"extraMachineCertSans,omitempty" jsonschema:"description=Additional certificate SANs to add to the machine certificate"`
 	Patches              []string                       `yaml:"patches,omitempty" jsonschema:"description=Patches to be applied to the node"`
 	TalosImageURL        string                         `yaml:"talosImageURL" jsonschema:"example=factory.talos.dev/installer/e9c7ef96884d4fbc8c0a1304ccca4bb0287d766a8b4125997cb9dbe84262144e,description=Talos installer image url for the node"`
 	NoSchematicValidate  bool                           `yaml:"noSchematicValidate" jsonschema:"description=Whether to skip schematic validation"`

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -20,6 +20,7 @@ func TestLoadAndValidateFromFile(t *testing.T) {
 		ControlPlane: true,
 		InstallDisk:  "/dev/sda",
 		NodeConfigs: NodeConfigs{
+			ExtraMachineCertSans: []string{"example.net", "example.com"},
 			Schematic: &schematic.Schematic{
 				Customization: schematic.Customization{
 					SystemExtensions: schematic.SystemExtensions{

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -20,7 +20,7 @@ func TestLoadAndValidateFromFile(t *testing.T) {
 		ControlPlane: true,
 		InstallDisk:  "/dev/sda",
 		NodeConfigs: NodeConfigs{
-			ExtraMachineCertSans: []string{"example.net", "example.com"},
+			ExtraCertSANs: []string{"example.net", "example.com"},
 			Schematic: &schematic.Schematic{
 				Customization: schematic.Customization{
 					SystemExtensions: schematic.SystemExtensions{

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -20,7 +20,7 @@ func TestLoadAndValidateFromFile(t *testing.T) {
 		ControlPlane: true,
 		InstallDisk:  "/dev/sda",
 		NodeConfigs: NodeConfigs{
-			ExtraCertSANs: []string{"example.net", "example.com"},
+			CertSANs: []string{"example.net", "example.com"},
 			Schematic: &schematic.Schematic{
 				Customization: schematic.Customization{
 					SystemExtensions: schematic.SystemExtensions{

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
-	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideMachineCertSans)
+	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideExtraMachineCertSans)
 
 	return node
 }

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -5,12 +5,12 @@ import (
 )
 
 func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
-	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideExtraCertSANs)
+	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideMachineCertSANs)
 
 	return node
 }
 
-func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest, overrideExtraCertSANs bool) NodeConfigs {
+func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest, overrideMachineCertSANs bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
 		// global patches should get applied first
 		// https://github.com/budimanjojo/talhelper/issues/388
@@ -19,8 +19,8 @@ func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraMani
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {
 		patch.ExtraManifests = append(patch.ExtraManifests, src.ExtraManifests...)
 	}
-	if len(src.ExtraCertSANs) > 0 && !overrideExtraCertSANs {
-		patch.ExtraCertSANs = append(patch.ExtraCertSANs, src.ExtraCertSANs...)
+	if len(src.CertSANs) > 0 && !overrideMachineCertSANs {
+		patch.CertSANs = append(patch.CertSANs, src.CertSANs...)
 	}
 
 	patchValue := reflect.ValueOf(patch)

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -5,12 +5,12 @@ import (
 )
 
 func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
-	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideExtraMachineCertSans)
+	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideExtraCertSANs)
 
 	return node
 }
 
-func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest, overrideMachineCertSans bool) NodeConfigs {
+func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest, overrideExtraCertSANs bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
 		// global patches should get applied first
 		// https://github.com/budimanjojo/talhelper/issues/388
@@ -19,8 +19,8 @@ func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraMani
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {
 		patch.ExtraManifests = append(patch.ExtraManifests, src.ExtraManifests...)
 	}
-	if len(src.ExtraMachineCertSans) > 0 && !overrideMachineCertSans {
-		patch.ExtraMachineCertSans = append(patch.ExtraMachineCertSans, src.ExtraMachineCertSans...)
+	if len(src.ExtraCertSANs) > 0 && !overrideExtraCertSANs {
+		patch.ExtraCertSANs = append(patch.ExtraCertSANs, src.ExtraCertSANs...)
 	}
 
 	patchValue := reflect.ValueOf(patch)
@@ -28,7 +28,7 @@ func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraMani
 
 	result := reflect.New(patchValue.Type()).Elem()
 
-	for i := 0; i < patchValue.NumField(); i++ {
+	for i := range patchValue.NumField() {
 		patchField := patchValue.Field(i)
 		srcField := srcValue.Field(i)
 

--- a/pkg/config/nodeconfigs.go
+++ b/pkg/config/nodeconfigs.go
@@ -5,12 +5,12 @@ import (
 )
 
 func (node *Node) OverrideGlobalCfg(cfg NodeConfigs) *Node {
-	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests)
+	node.NodeConfigs = mergeNodeConfigs(node.NodeConfigs, cfg, node.OverridePatches, node.OverrideExtraManifests, node.OverrideMachineCertSans)
 
 	return node
 }
 
-func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest bool) NodeConfigs {
+func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraManifest, overrideMachineCertSans bool) NodeConfigs {
 	if len(src.Patches) > 0 && !overridePatches {
 		// global patches should get applied first
 		// https://github.com/budimanjojo/talhelper/issues/388
@@ -18,6 +18,9 @@ func mergeNodeConfigs(patch, src NodeConfigs, overridePatches, overrideExtraMani
 	}
 	if len(src.ExtraManifests) > 0 && !overrideExtraManifest {
 		patch.ExtraManifests = append(patch.ExtraManifests, src.ExtraManifests...)
+	}
+	if len(src.ExtraMachineCertSans) > 0 && !overrideMachineCertSans {
+		patch.ExtraMachineCertSans = append(patch.ExtraMachineCertSans, src.ExtraMachineCertSans...)
 	}
 
 	patchValue := reflect.ValueOf(patch)

--- a/pkg/config/testdata/talconfig.yaml
+++ b/pkg/config/testdata/talconfig.yaml
@@ -5,7 +5,7 @@ additionalMachineCertSans:
 nodes:
   - hostname: ${HOSTNAME1}
     ipAddress: ${IP1}
-    extraCertSANs:
+    certSANs:
       - example.net
     installDisk: /dev/sda
     controlPlane: true
@@ -19,7 +19,7 @@ nodes:
     installDisk: /dev/sda
     controlPlane: false
 controlPlane:
-  extraCertSANs:
+  certSANs:
     - example.com
   disableSearchDomain: true
   schematic:

--- a/pkg/config/testdata/talconfig.yaml
+++ b/pkg/config/testdata/talconfig.yaml
@@ -5,7 +5,7 @@ additionalMachineCertSans:
 nodes:
   - hostname: ${HOSTNAME1}
     ipAddress: ${IP1}
-    extraMachineCertSans:
+    extraCertSANs:
       - example.net
     installDisk: /dev/sda
     controlPlane: true
@@ -19,7 +19,7 @@ nodes:
     installDisk: /dev/sda
     controlPlane: false
 controlPlane:
-  extraMachineCertSans:
+  extraCertSANs:
     - example.com
   disableSearchDomain: true
   schematic:

--- a/pkg/config/testdata/talconfig.yaml
+++ b/pkg/config/testdata/talconfig.yaml
@@ -1,9 +1,12 @@
----
 clusterName: test-cluster
 endpoint: https://192.168.200.10:6443
+additionalMachineCertSans:
+  - example.org
 nodes:
   - hostname: ${HOSTNAME1}
     ipAddress: ${IP1}
+    extraMachineCertSans:
+      - example.net
     installDisk: /dev/sda
     controlPlane: true
     schematic:
@@ -16,6 +19,8 @@ nodes:
     installDisk: /dev/sda
     controlPlane: false
 controlPlane:
+  extraMachineCertSans:
+    - example.com
   disableSearchDomain: true
   schematic:
     customization:

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -133,6 +133,11 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs = append(cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs, node.Schematic.Customization.ExtraKernelArgs...)
 	}
 
+	if len(node.ExtraMachineCertSans) > 0 {
+		slog.Debug("appending extra machine certificate SANs")
+		cfg.RawV1Alpha1().MachineConfig.MachineCertSANs = append(cfg.RawV1Alpha1().MachineConfig.MachineCertSANs, node.ExtraMachineCertSans...)
+	}
+
 	return cfg
 }
 

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -133,9 +133,9 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs = append(cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs, node.Schematic.Customization.ExtraKernelArgs...)
 	}
 
-	if len(node.ExtraMachineCertSans) > 0 {
+	if len(node.ExtraCertSANs) > 0 {
 		slog.Debug("appending extra machine certificate SANs")
-		cfg.RawV1Alpha1().MachineConfig.MachineCertSANs = append(cfg.RawV1Alpha1().MachineConfig.MachineCertSANs, node.ExtraMachineCertSans...)
+		cfg.RawV1Alpha1().MachineConfig.MachineCertSANs = append(cfg.RawV1Alpha1().MachineConfig.MachineCertSANs, node.ExtraCertSANs...)
 	}
 
 	return cfg

--- a/pkg/talos/nodeconfig.go
+++ b/pkg/talos/nodeconfig.go
@@ -133,9 +133,9 @@ func applyNodeOverride(node *config.Node, cfg taloscfg.Provider) taloscfg.Provid
 		cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs = append(cfg.RawV1Alpha1().MachineConfig.MachineInstall.InstallExtraKernelArgs, node.Schematic.Customization.ExtraKernelArgs...)
 	}
 
-	if len(node.ExtraCertSANs) > 0 {
+	if len(node.CertSANs) > 0 {
 		slog.Debug("appending extra machine certificate SANs")
-		cfg.RawV1Alpha1().MachineConfig.MachineCertSANs = append(cfg.RawV1Alpha1().MachineConfig.MachineCertSANs, node.ExtraCertSANs...)
+		cfg.RawV1Alpha1().MachineConfig.MachineCertSANs = append(cfg.RawV1Alpha1().MachineConfig.MachineCertSANs, node.CertSANs...)
 	}
 
 	return cfg


### PR DESCRIPTION
This adds a new `extraMachineCertSans` & `overrideExtraMachineCertSans` node & node group config option and deprecates the `additionalMachineCertSans` as a general option.

The `additionalMachineCertSans` field is not needed anymore since this can be easily done via node groups. Thus it is flagged as Deprecated in the documentation. JSON Schema and or [invopop/jsonschema](https://github.com/invopop/jsonschema) does not support deprecations. This could be usefull to flag in the schema

For the time being `additionalmachineCertSans` works as expected and `extraMachineCertSans` add on top of that. Both are appended to another (no duplication filtering for now).

I added two fields to the testdata to test if the new option works as expected. The `additionalMachineCertSans` was tested manually for regressions.