### PR TITLE
fix(loader): paths of `extraManifests` should be relative to config file

### DIFF
--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -634,7 +634,7 @@ func checkNodeExtraManifests(node Node, idx int, result *Errors) *Errors {
 		var messages *multierror.Error
 
 		for k, manifest := range node.ExtraManifests {
-			if _, osErr := os.Stat(manifest); osErr != nil {
+			if _, osErr := os.Stat(strings.TrimPrefix(manifest, "@")); osErr != nil {
 				messages = multierror.Append(messages, fmt.Errorf("extraManifests[%d], %q", k, osErr))
 			}
 		}

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
@@ -188,7 +189,7 @@ func getFileContentByte(path string) ([]byte, error) {
 func combineExtraManifests(extraFiles []string) ([]byte, error) {
 	var result [][]byte
 	for _, file := range extraFiles {
-		content, err := getFileContentByte(file)
+		content, err := getFileContentByte(strings.TrimPrefix(file, "@"))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/substitute/pathsubst_test.go
+++ b/pkg/substitute/pathsubst_test.go
@@ -150,6 +150,32 @@ machineFiles:
   - content: "@ "
 `,
 		},
+		{
+			name: "No substitution for absolute path",
+			yamlContent: `
+machineFiles:
+  - content: "@/path/to/file1.txt"
+`,
+			expectedOutput: `
+machineFiles:
+  - content: "@/path/to/file1.txt"
+`,
+		},
+		{
+			name: "Special extraManifests without '@' being substituted",
+			yamlContent: `
+extraManifests:
+  - "./relative/file1.yaml"
+  - "/path/to/relative/file2.yaml"
+  - "@./relative/file3.yaml"
+`,
+			expectedOutput: `
+extraManifests:
+  - "@/path/to/relative/file1.yaml"
+  - "@/path/to/relative/file2.yaml"
+  - "@/path/to/relative/file3.yaml"
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When `extraManifests` is a list of relative paths, they were not being substituted to the absolute paths of `--config-file` flag.
`SubstituteRelativePaths` didn't work for `extraManifests` because the values doesn't need the `@` prefix before the file name.
Now, we just internally add the `@` prefix and call it a "special" case to simplify the code base.

This also fixes the case where absolute paths are given instead of relative paths.
Before this, they're joined to the directory of config file while now it should just be returned as if.

Fixes: https://github.com/budimanjojo/talhelper/issues/871
