### PR TITLE
`MachineDisks` is deprecated, use `UserVolumeConfig` instead

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -509,6 +509,25 @@ volumes:
 </tr>
 
 <tr markdown="1">
+<td markdown="1">`userVolumes`</td>
+<td markdown="1">[][UserVolume](#uservolume)</td>
+<td markdown="1">Machine user volume configs specification.<details><summary>*Show example*</summary>
+```yaml
+userVolumes:
+  - name: ceph-data
+    provisioning:
+      diskSelector:
+        match: disk.transport == "nvme"
+      maxSize: 50GiB
+    filesystem:
+      type: xfs
+```
+</summary></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+<tr markdown="1">
 <td markdown="1">`nodeLabels`</td>
 <td markdown="1">map[string]string</td>
 <td markdown="1">Labels to be added to the node.<details><summary>*Show example*</summary>
@@ -1034,6 +1053,57 @@ provisioning:
 
 </table>
 
+## UserVolume
+
+`UserVolume` defines machine user volume configuration for a node.
+
+<table markdown="1">
+<tr markdown="1">
+<th markdown="1">Field</th><th>Type</th><th>Description</th><th>Default Value</th><th>Required</th>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`name`</td>
+<td markdown="1">`string`</td>
+<td markdown="1">Name of the volume config.<details><summary>*Show example*</summary>
+```yaml
+name: ceph-data
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`provisioning`</td>
+<td markdown="1">[ProvisioningSpec](#provisioningspec)</td>
+<td markdown="1">Provisioning spec of the volume config.<details><summary>*Show example*</summary>
+```yaml
+provisioning:
+  diskSelector:
+    match: disk.transport == "nvme"
+  maxSize: 50GiB
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:white_check_mark:</td>
+</tr>
+
+<tr markdown="1">
+<td markdown="1">`filesystem`</td>
+<td markdown="1">[FilesystemSpec](#filesystemspec)</td>
+<td markdown="1">Filesystem spec of the volume config.<details><summary>*Show example*</summary>
+```yaml
+filesystem:
+  type: xfs
+```
+</details></td>
+<td markdown="1" align="center">`nil`</td>
+<td markdown="1" align="center">:negative_squared_cross_mark:</td>
+</tr>
+
+</table>
+
 ## NetworkRule
 
 `NetworkRule` defines the firewall rules to match.
@@ -1141,3 +1211,7 @@ In addition to this, there's also a `skipEnvsubst` key that can be set to `true`
 ## ProvisioningSpec
 
 `ProvisioningSpec` is type of upstream Talos <a href="https://www.talos.dev/v1.9/reference/configuration/block/volumeconfig/#VolumeConfig.provisioning" target="_blank">`block.ProvisioningSpec`</a>
+
+## FilesystemSpec
+
+`FilesystemSpec` is type of upstream Talos <a href="https://www.talos.dev/v1.10/reference/configuration/block/uservolumeconfig/#UserVolumeConfig.filesystem" target="_blank">`block.ProvisioningSpec`</a>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -559,7 +559,7 @@ disableSearchDomain: true
 <tr markdown="1">
 <td markdown="1">`machineDisks`</td>
 <td markdown="1">[][MachineDisk](#machinedisk)</td>
-<td markdown="1">List of additional disks to partition, format, mount.<details><summary>*Show example*</summary>
+<td markdown="1">DEPRECATED: use `userVolumes` instead.<details><summary>*Show example*</summary>
 ```yaml
 machineDisks:
   - device: /dev/disk/by-id/ata-CT500MX500SSD1_2149E5EC1D9D

--- a/example/talconfig.yaml
+++ b/example/talconfig.yaml
@@ -32,6 +32,19 @@ nodes:
             mountPath: /usr/local/etc/nut/upsmon.conf
         environment:
           - UPS_NAME=ups
+    userVolumes:
+      - name: ceph-data
+        provisioning:
+          diskSelector:
+            match: disk.transport == "nvme"
+          maxSize: 50GiB
+        filesystem:
+          type: xfs
+      - name: sata
+        provisioning:
+          diskSelector:
+            match: disk.transport == "sata"
+          minSize: 100GiB
     volumes:
       - name: EPHEMERAL
         provisioning:
@@ -101,10 +114,6 @@ nodes:
       - name: br_netfilter
         parameters:
           - nf_conntrack_max=131072
-    machineDisks:
-      - device: /dev/disk/by-id/ata-CT500MX500SSD1_2149E5EC1D9D
-        partitions:
-          - mountpoint: /var/mnt/sata
     nameservers:
       - 1.1.1.1
       - 8.8.8.8

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ type NodeConfigs struct {
 	IngressFirewall     *IngressFirewall               `yaml:"ingressFirewall,omitempty" jsonschema:"description=Machine firewall specification"`
 	ExtensionServices   []*ExtensionService            `yaml:"extensionServices,omitempty" jsonschema:"description=Machine extension services specification"`
 	Volumes             []*Volume                      `yaml:"volumes,omitempty" jsonschema:"description=Machine volume configs specification"`
+	UserVolumes         []*UserVolume                  `yaml:"userVolumes,omitempty" jsonschema:"description=Machine user volume configs specification"`
 }
 
 type ImageFactory struct {
@@ -98,6 +99,12 @@ type ExtensionService struct {
 	Name        string                    `yaml:"name" jsonschema:"description=Name of the extension service config"`
 	ConfigFiles extensions.ConfigFileList `yaml:"configFiles,omitempty" jsonschema:"description=The config files for the extension service"`
 	Environment []string                  `yaml:"environment,omitempty" jsonschema:"description=The environment for the extension service"`
+}
+
+type UserVolume struct {
+	Name         string                 `yaml:"name" jsonschema:"description=Name of user volume config"`
+	Provisioning block.ProvisioningSpec `yaml:"provisioning" jsonschema:"description=Provisioning spec of the user volume config"`
+	Filesystem   block.FilesystemSpec   `yaml:"filesystem" jsonschema:"description=Filesystem spec of the user volume config"`
 }
 
 type Volume struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,7 @@ type NodeConfigs struct {
 	NodeLabels          map[string]string              `yaml:"nodeLabels" jsonschema:"description=Labels to be added to the node, supports templating"`
 	NodeAnnotations     map[string]string              `yaml:"nodeAnnotations" jsonschema:"description=Annotations to be added to the node, supports templating"`
 	NodeTaints          map[string]string              `yaml:"nodeTaints" jsonschema:"description=Node taints for the node. Effect is optional"`
-	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=List of additional disks to partition, format, mount"`
+	MachineDisks        []*v1alpha1.MachineDisk        `yaml:"machineDisks,omitempty" jsonschema:"description=DEPRECATED: user \"userVolumes\" instead"`
 	MachineFiles        MachineFiles                   `yaml:"machineFiles,omitempty" jsonschema:"description=List of files to create inside the node"`
 	DisableSearchDomain bool                           `yaml:"disableSearchDomain,omitempty" jsonschema:"description=Whether to disable generating default search domain"`
 	KernelModules       []*v1alpha1.KernelModuleConfig `yaml:"kernelModules,omitempty" jsonschema:"description=List of additional kernel modules to load inside the node"`

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -57,7 +57,7 @@ func (c TalhelperConfig) Validate() (Errors, Warnings) {
 		checkNodeLabels(node, k, &result)
 		checkNodeAnnotations(node, k, &result)
 		checkNodeTaints(node, k, &result)
-		checkNodeMachineDisks(node, k, &result)
+		checkNodeMachineDisks(node, k, &result, &warns)
 		checkNodeMachineFiles(node, k, &result)
 		if c.GetImageFactory().RegistryURL == "factory.talos.dev" && !node.NoSchematicValidate {
 			slog.Debug(fmt.Sprintf("validating schematic with official Talos schematic for node %s", node.Hostname))

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -365,8 +365,14 @@ func checkNodeTaints(node Node, idx int, result *Errors) *Errors {
 	return result
 }
 
-func checkNodeMachineDisks(node Node, idx int, result *Errors) *Errors {
+func checkNodeMachineDisks(node Node, idx int, result *Errors, warns *Warnings) (*Errors, *Warnings) {
 	if node.MachineDisks != nil {
+		warns.Append(&Warning{
+			Kind:    "DeprecatedNodeMachineDisks",
+			Field:   getNodeFieldYamlTag(node, idx, "MachineDisks"),
+			Message: formatWarning("`machineDisks` is deprecated, please use `userVolumes` instead"),
+		})
+
 		var messages *multierror.Error
 
 		for _, disk := range node.MachineDisks {
@@ -382,10 +388,10 @@ func checkNodeMachineDisks(node Node, idx int, result *Errors) *Errors {
 				Kind:    "InvalidMachineDisks",
 				Field:   getNodeFieldYamlTag(node, idx, "MachineDisks"),
 				Message: formatError(messages),
-			})
+			}), warns
 		}
 	}
-	return result
+	return result, warns
 }
 
 func checkNodeMachineFiles(node Node, idx int, result *Errors) *Errors {

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -102,6 +102,15 @@ func GenerateConfig(c *config.TalhelperConfig, dryRun bool, outDir, secretFile, 
 			cfg = append(cfg, vc...)
 		}
 
+		if len(node.UserVolumes) > 0 {
+			slog.Debug(fmt.Sprintf("generating user volume config for %s", node.Hostname))
+			uvc, err := talos.GenerateUserVolumeConfigBytes(node.UserVolumes, mode)
+			if err != nil {
+				return err
+			}
+			cfg = append(cfg, uvc...)
+		}
+
 		if len(node.ExtraManifests) > 0 {
 			slog.Debug(fmt.Sprintf("generating extra manifests for %s", node.Hostname))
 			content, err := combineExtraManifests(node.ExtraManifests)

--- a/pkg/talos/uservolumeconfig.go
+++ b/pkg/talos/uservolumeconfig.go
@@ -1,0 +1,61 @@
+package talos
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
+)
+
+func GenerateUserVolumeConfigBytes(cfgs []*config.UserVolume, mode string) ([]byte, error) {
+	var result [][]byte
+
+	uvcs, err := GenerateUserVolumeConfig(cfgs, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, uvc := range uvcs {
+		uvcByte, err := marshalYaml(uvc)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, uvcByte)
+	}
+
+	return CombineYamlBytes(result), nil
+}
+
+func GenerateUserVolumeConfig(cfgs []*config.UserVolume, mode string) ([]*block.UserVolumeConfigV1Alpha1, error) {
+	var (
+		// I suppose we shouldn't allow same volume names?
+		names  []string
+		result []*block.UserVolumeConfigV1Alpha1
+	)
+
+	m, err := parseMode(mode)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, uv := range cfgs {
+		if slices.Index(names, uv.Name) != -1 {
+			return nil, fmt.Errorf("duplicated user volume config name found: %s", uv.Name)
+		}
+		names = append(names, uv.Name)
+		uvc := block.NewUserVolumeConfigV1Alpha1()
+		uvc.MetaName = uv.Name
+		uvc.ProvisioningSpec = uv.Provisioning
+		uvc.FilesystemSpec = uv.Filesystem
+
+		if _, err := uvc.Validate(m); err != nil {
+			return nil, err
+		}
+
+		result = append(result, uvc)
+	}
+
+	return result, nil
+}

--- a/pkg/talos/uservolumeconfig_test.go
+++ b/pkg/talos/uservolumeconfig_test.go
@@ -1,0 +1,63 @@
+package talos
+
+import (
+	"testing"
+
+	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/siderolabs/talos/pkg/machinery/cel"
+	"github.com/siderolabs/talos/pkg/machinery/cel/celenv"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/block"
+	blocktype "github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGenerateNodeUserVolumeConfig(t *testing.T) {
+	data := []byte(`nodes:
+  - hostname: node1
+    userVolumes:
+      - name: ceph-data
+        provisioning:
+          diskSelector:
+            match: disk.transport == "nvme"
+          maxSize: 50GiB
+        filesystem:
+          type: xfs
+      - name: ceph-data2
+        provisioning:
+          diskSelector:
+            match: disk.size > 120u * GB && disk.size < 1u * TB
+          minSize: 1GiB`)
+	var m config.TalhelperConfig
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedVolume1Name := "ceph-data"
+	expectedVolume1Provisioning := block.ProvisioningSpec{
+		DiskSelectorSpec: block.DiskSelector{
+			Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.transport == "nvme"`, celenv.DiskLocator())),
+		},
+		ProvisioningMaxSize: block.MustByteSize("50GiB"),
+	}
+	expectedVolume1Filesystem := block.FilesystemSpec{
+		FilesystemType: blocktype.FilesystemTypeXFS,
+	}
+	expectedVolume2Name := "ceph-data2"
+	expectedVolume2Provisioning := block.ProvisioningSpec{
+		DiskSelectorSpec: block.DiskSelector{
+			Match: cel.MustExpression(cel.ParseBooleanExpression(`disk.size > 120u * GB && disk.size < 1u * TB`, celenv.DiskLocator())),
+		},
+		ProvisioningMinSize: block.MustByteSize("1GiB"),
+	}
+
+	result, err := GenerateUserVolumeConfig(m.Nodes[0].UserVolumes, "metal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compare(result[0].Name(), expectedVolume1Name, t)
+	compare(result[0].ProvisioningSpec, expectedVolume1Provisioning, t)
+	compare(result[0].FilesystemSpec, expectedVolume1Filesystem, t)
+	compare(result[1].Name(), expectedVolume2Name, t)
+	compare(result[1].ProvisioningSpec, expectedVolume2Provisioning, t)
+}


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/941

- **feat(config): deprecate `machineDisks`**
- **feat(config): add `userVolumes` to generate `UserVolumeConfig`**
