### PR TITLE
feat(genconfig): reflect to the installer image url change

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -816,12 +816,12 @@ schematicEndpoint: /schematics
 <tr markdown="1">
 <td markdown="1">`installerURLTmpl`</td>
 <td markdown="1">string</td>
-<td markdown="1"><details><summary>Go template to parse the full installer URL.</summary>Available placeholders: `RegistryURL`,`ID`,`Version`, `Secureboot`</details><details><summary>*Show example*</summary>
+<td markdown="1"><details><summary>Go template to parse the full installer URL.</summary>Available placeholders: `RegistryURL`,`ID`,`Version`, `Secureboot`, `Mode`</details><details><summary>*Show example*</summary>
 ```yaml
 installerURLTmpl: "{{.RegistryURL}}/installer/{{.ID}}:{{.Version}}"
 ```
 </summary></td>
-<td markdown="1" align="center">`{{.RegistryURL}}/installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}}`</td>
+<td markdown="1" align="center">`{{.RegistryURL}}/{{.Mode}}-installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}}`</td>
 <td markdown="1" align="center">:negative_squared_cross_mark:</td>
 </tr>
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -78,7 +78,7 @@ func (c *TalhelperConfig) GetImageFactory() *ImageFactory {
 		RegistryURL:       "factory.talos.dev",
 		SchematicEndpoint: "/schematics",
 		Protocol:          "https",
-		InstallerURLTmpl:  "{{.RegistryURL}}/installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}}",
+		InstallerURLTmpl:  "{{.RegistryURL}}/{{.Mode}}-installer{{if .Secureboot}}-secureboot{{end}}/{{.ID}}:{{.Version}}",
 		ImageURLTmpl:      "{{.Protocol}}://{{.RegistryURL}}/image/{{.ID}}/{{.Version}}/{{.Mode}}-{{.Arch}}{{if .Secureboot}}-secureboot{{end}}{{if and .Secureboot .UseUKI}}-uki.efi{{ else }}{{.Suffix}}{{end}}",
 	}
 	if c.ImageFactory.RegistryURL != "" {

--- a/pkg/talos/nodeconfig_test.go
+++ b/pkg/talos/nodeconfig_test.go
@@ -127,7 +127,7 @@ nodes:
 			},
 		},
 	}
-	expectedNode1InstallImage := "factory.talos.dev/installer/647a0a54bff662aa12051bc0312097f29d3562107d8e6a8e87ab85b643e25bc0:v1.5.4"
+	expectedNode1InstallImage := "factory.talos.dev/metal-installer/647a0a54bff662aa12051bc0312097f29d3562107d8e6a8e87ab85b643e25bc0:v1.5.4"
 	expectedNode1InstallExtraKernelArgs := []string{"hello", "hihi"}
 	expectedNode2Type := "worker"
 	expectedNode2InstallDiskSelector := &v1alpha1.InstallDiskSelector{

--- a/pkg/talos/schematic.go
+++ b/pkg/talos/schematic.go
@@ -26,6 +26,7 @@ type installerTmpl struct {
 	RegistryURL string
 	ID          string
 	Version     string
+	Mode        string
 	Secureboot  bool
 }
 
@@ -46,6 +47,7 @@ func GetInstallerURL(cfg *schematic.Schematic, factory *config.ImageFactory, spe
 	tmplData := installerTmpl{
 		RegistryURL: factory.RegistryURL,
 		Version:     version,
+		Mode:        spec.Mode,
 		Secureboot:  spec.Secureboot,
 	}
 

--- a/pkg/talos/schematic_test.go
+++ b/pkg/talos/schematic_test.go
@@ -58,9 +58,11 @@ func TestGetInstallerURL(t *testing.T) {
 			iFactory: &config.ImageFactory{
 				RegistryURL: "factory.talos.dev",
 			},
-			machineSpec: &config.MachineSpec{},
+			machineSpec: &config.MachineSpec{
+				Mode: "metal",
+			},
 			version:     "v1.5.4",
-			expectedURL: "factory.talos.dev/installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.5.4",
+			expectedURL: "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.5.4",
 		},
 
 		{
@@ -75,9 +77,11 @@ func TestGetInstallerURL(t *testing.T) {
 			iFactory: &config.ImageFactory{
 				RegistryURL: "",
 			},
-			machineSpec: &config.MachineSpec{},
+			machineSpec: &config.MachineSpec{
+				Mode: "metal",
+			},
 			version:     "v1.5.4",
-			expectedURL: "factory.talos.dev/installer/98442b5bb4e8d050f30978ce3e6ec22e7bf534d57cafcd51313235128057e612:v1.5.4",
+			expectedURL: "factory.talos.dev/metal-installer/98442b5bb4e8d050f30978ce3e6ec22e7bf534d57cafcd51313235128057e612:v1.5.4",
 		},
 
 		{
@@ -87,9 +91,11 @@ func TestGetInstallerURL(t *testing.T) {
 					ExtraKernelArgs: []string{"hihi", "hehe"},
 				},
 			},
-			iFactory:    &config.ImageFactory{},
-			machineSpec: &config.MachineSpec{},
-			expectedURL: "factory.talos.dev/installer/ff5083b14ccb03821ea738d712ac08a82b44d2693013622059edaae286665239:",
+			iFactory: &config.ImageFactory{},
+			machineSpec: &config.MachineSpec{
+				Mode: "gcp",
+			},
+			expectedURL: "factory.talos.dev/gcp-installer/ff5083b14ccb03821ea738d712ac08a82b44d2693013622059edaae286665239:",
 		},
 
 		{
@@ -106,10 +112,11 @@ func TestGetInstallerURL(t *testing.T) {
 				RegistryURL: "test.registry/",
 			},
 			machineSpec: &config.MachineSpec{
+				Mode:       "metal",
 				Secureboot: true,
 			},
 			version:     "1.5.4",
-			expectedURL: "test.registry//installer-secureboot/104c23dfe7c5bfeff6a4cc7e166d8b3bba0f371760592c7677c90c822bb1d109:1.5.4",
+			expectedURL: "test.registry//metal-installer-secureboot/104c23dfe7c5bfeff6a4cc7e166d8b3bba0f371760592c7677c90c822bb1d109:1.5.4",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -120,7 +127,7 @@ func TestGetInstallerURL(t *testing.T) {
 				t.Fatal(err)
 			}
 			if url != test.expectedURL {
-				t.Errorf("got %s, want %s", url, test.expectedURL)
+				t.Errorf("test: %s\ngot : %s\nwant: %s", test.name, url, test.expectedURL)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes: https://github.com/budimanjojo/talhelper/issues/982

It seems like v1.10.0 the upstream `image-factory` gives out installer
url in new format. The baremetal platform before and after the change:
Before:
`factory.talos.dev/installer/abcdefg:v1.10.0`
After:
`factory.talos.dev/metal-installer/abcdefg:v1.10.0`

Although it seems like using the old url will pull the image just fine,
 it's better if we follow the new url instead
