### PR TITLE
feat(config): allow go templating in `patches`

### DIFF
--- a/docs/docs/guides.md
+++ b/docs/docs/guides.md
@@ -167,9 +167,9 @@ nodes:
 You can add `ingressFirewall` and `extraManifests` below `controlPlane` or `worker` field for node groups that you want to apply.
 Or you can add them to `nodes[]` field for specific node you want to apply.
 
-## Templating extra manifests
+## Templating patches
 
-You can use Go templating inside the files listed under `extraManifests`.
+You can use Go templating inside the files listed under `patches`.
 Let's say you want to generate `v1alpha1.NetworkRuleConfig` that accepts/blocks port `50000` or `50001` depending on the node type coming from your `serviceSubnets` network:
 
 ```yaml title="./talconfig.yaml"
@@ -181,12 +181,12 @@ clusterSvcNets:
 nodes:
   - hostname: cp
     controlPlane: true
-    extraManifests:
-      - ./firewall.yaml
+    patches:
+      - @./firewall.yaml
   - hostname: worker
     controlPlane: false
-    extraManifests:
-      - ./firewall.yaml
+    patches:
+      - @./firewall.yaml
 ```
 
 ```yaml title="./firewall.yaml"

--- a/pkg/patcher/patcher_test.go
+++ b/pkg/patcher/patcher_test.go
@@ -2,6 +2,7 @@ package patcher
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
@@ -54,7 +55,7 @@ func TestYAMLInlinePatcher(t *testing.T) {
     d: added
   c: original
 `
-	var m map[interface{}]interface{}
+	var m map[any]any
 	if err := yaml.Unmarshal([]byte(patch), &m); err != nil {
 		t.Fatal(err)
 	}
@@ -123,5 +124,30 @@ version: v1alpha1
 
 	if string(expectedByte) != string(result) {
 		t.Errorf("got %s, want %s", string(result), string(expectedByte))
+	}
+}
+
+func TestPatchesPatherTemplating(t *testing.T) {
+	data := []string{"templating0", "templating1", "templating2"}
+
+	for _, d := range data {
+		base, err := os.ReadFile("testdata/" + d + "_base.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := PatchesPatcher([]string{"@./testdata/" + d + "_input.yaml"}, base)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected, err := os.ReadFile("testdata/" + d + "_expected.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(expected, result) {
+			t.Errorf("%s\ngot:\n%v\nwant:\n%v", d, string(result), string(expected))
+		}
 	}
 }

--- a/pkg/patcher/testdata/templating0_base.yaml
+++ b/pkg/patcher/testdata/templating0_base.yaml
@@ -1,0 +1,7 @@
+---
+version: v1alpha1
+machine:
+  type: worker
+  token: ""
+  network:
+    hostname: foo.bar

--- a/pkg/patcher/testdata/templating0_expected.yaml
+++ b/pkg/patcher/testdata/templating0_expected.yaml
@@ -1,0 +1,14 @@
+version: v1alpha1
+machine:
+    type: worker
+    token: ""
+    certSANs: []
+    network:
+        hostname: foo.bar
+    logging:
+        destinations:
+            - endpoint: udp://127.0.0.1:123456/
+              format: json_lines
+              extraTags:
+                server: foo.bar
+cluster: null

--- a/pkg/patcher/testdata/templating0_input.yaml
+++ b/pkg/patcher/testdata/templating0_input.yaml
@@ -1,0 +1,8 @@
+---
+machine:
+  logging:
+    destinations:
+      - endpoint: "udp://127.0.0.1:123456/"
+        format: json_lines
+        extraTags:
+          server: "{{ .MachineConfig.MachineNetwork.NetworkHostname }}"

--- a/pkg/patcher/testdata/templating1_base.yaml
+++ b/pkg/patcher/testdata/templating1_base.yaml
@@ -1,0 +1,12 @@
+---
+version: v1alpha1
+machine:
+    type: ""
+    token: ""
+    certSANs: []
+    network:
+        hostname: hostname1
+        interfaces:
+            - interface: eth0
+              dhcp: false
+cluster: null

--- a/pkg/patcher/testdata/templating1_expected.yaml
+++ b/pkg/patcher/testdata/templating1_expected.yaml
@@ -1,0 +1,23 @@
+version: v1alpha1
+machine:
+    type: ""
+    token: ""
+    certSANs: []
+    network:
+        hostname: hostname1
+        interfaces:
+            - interface: eth0
+              dhcp: false
+cluster: null
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: hostname1
+configFiles:
+    - content: hello world
+      mountPath: /etc/foo
+    - content: another hello
+      mountPath: /etc/bar
+environment:
+    - FOO=BAR
+    - XXX=YYY

--- a/pkg/patcher/testdata/templating1_input.yaml
+++ b/pkg/patcher/testdata/templating1_input.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: "{{ .MachineConfig.MachineNetwork.NetworkHostname }}"
+configFiles:
+    - content: hello world
+      mountPath: /etc/foo
+    - content: another hello
+      mountPath: /etc/bar
+environment:
+    - FOO=BAR
+    - XXX=YYY

--- a/pkg/patcher/testdata/templating2_base.yaml
+++ b/pkg/patcher/testdata/templating2_base.yaml
@@ -1,0 +1,15 @@
+---
+version: v1alpha1
+machine:
+    type: worker
+    token: ""
+    certSANs: []
+    network:
+        hostname: hostname1
+        interfaces:
+            - interface: eth0
+              dhcp: false
+cluster:
+    network:
+        serviceSubnets:
+            - 10.96.0.0/12

--- a/pkg/patcher/testdata/templating2_expected.yaml
+++ b/pkg/patcher/testdata/templating2_expected.yaml
@@ -1,0 +1,27 @@
+version: v1alpha1
+machine:
+    type: worker
+    token: ""
+    certSANs: []
+    network:
+        hostname: hostname1
+        interfaces:
+            - interface: eth0
+              dhcp: false
+cluster:
+    controlPlane: null
+    network:
+        dnsDomain: ""
+        podSubnets: []
+        serviceSubnets:
+            - 10.96.0.0/12
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: testing
+portSelector:
+    ports:
+        - 50001
+    protocol: tcp
+ingress:
+    - subnet: 10.96.0.0/12

--- a/pkg/patcher/testdata/templating2_input.yaml
+++ b/pkg/patcher/testdata/templating2_input.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: testing
+portSelector:
+  ports:
+{{- if ne .MachineConfig.MachineType "worker" }}
+    - 50000
+{{- else }}
+    - 50001
+{{- end }}
+  protocol: tcp
+ingress:
+{{- range $subnet := .ClusterConfig.ClusterNetwork.ServiceSubnet }}
+  - subnet: {{ $subnet }}
+{{- end -}}


### PR DESCRIPTION
This allows having go templating in `patches`.
The data that can be used is the base v1alpha1 MachineConfig before the patches being applied.
Note that the key names are not the same as the yaml fields, they are the go struct fields that you can find in the [upstream sourcecode](https://raw.githubusercontent.com/siderolabs/talos/refs/heads/main/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go).
For example, to get the value of `machine.network.hostname` the template should be `{{ .MachineConfig.MachineNetwork.NetworkHostname }}`.

Example usage:

**talconfig.yaml**
```yaml
---
clusterName: mycluster
clusterSvcNets:
  - 10.96.0.0/12
  - 2001:db8::/64
nodes:
  - hostname: cp
    controlPlane: true
    extraManifests:
      - ./firewall.yaml
  - hostname: worker
    controlPlane: false
    extraManifests:
      - ./firewall.yaml
```

**firewall.yaml**
```yaml
---
apiVersion: v1alpha1
kind: NetworkRuleConfig
name: testing
portSelector:
  ports:
{{- if ne .MachineConfig.MachineType "worker" }}
    - 50000
{{- else }}
    - 50001
{{- end }}
  protocol: tcp
ingress:
{{- range $subnet := .ClusterConfig.ClusterNetwork.ServiceSubnet }}
  - subnet: {{ $subnet }}
{{- end -}}
```

One thing to note is that as you can see above, the templating have `{{ $subnet }}`, so that means the patch **needs** to be in a separate file, it won't work for patches defined in the `talconfig.yaml` because the `$subnet` will get envsubstituted and breaks the templating.