### PR TITLE
feat: add --context flag to use clusterName as talosctl contextAdd context flag to gencommand commands

### DIFF
--- a/cmd/gencommand.go
+++ b/cmd/gencommand.go
@@ -11,6 +11,7 @@ var (
 	gencommandEnvFile    []string
 	gencommandExtraFlags []string
 	gencommandNode       string
+	gencommandContext    bool
 )
 
 var gencommandCmd = &cobra.Command{
@@ -25,5 +26,6 @@ func init() {
 	gencommandCmd.PersistentFlags().StringSliceVarP(&gencommandEnvFile, "env-file", "e", []string{"talenv.yaml", "talenv.sops.yaml", "talenv.yml", "talenv.sops.yml"}, "List of files containing env variables for config file")
 	gencommandCmd.PersistentFlags().StringSliceVar(&gencommandExtraFlags, "extra-flags", []string{}, "List of additional flags that will be injected into the generated commands.")
 	gencommandCmd.PersistentFlags().StringVarP(&gencommandNode, "node", "n", "", "A specific node to generate the command for. If not specified, will generate for all nodes.")
+	gencommandCmd.PersistentFlags().BoolVar(&gencommandContext, "context", false, "Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.")
 	_ = helpers.MakeNodeCompletion(gencommandCmd)
 }

--- a/cmd/gencommand_upgrade-k8s.go
+++ b/cmd/gencommand_upgrade-k8s.go
@@ -19,7 +19,7 @@ var gencommandUpgradeK8sCmd = &cobra.Command{
 			log.Fatalf("failed to parse config file: %s", err)
 		}
 
-		err = generate.GenerateUpgradeK8sCommand(cfg, gencommandOutDir, gencommandNode, gencommandExtraFlags)
+		err = generate.GenerateUpgradeK8sCommand(cfg, gencommandOutDir, gencommandNode, gencommandExtraFlags, gencommandContext)
 		if err != nil {
 			log.Fatalf("failed to generate talosctl upgrade-k8s command: %s", err)
 		}

--- a/cmd/gencommand_upgrade.go
+++ b/cmd/gencommand_upgrade.go
@@ -19,7 +19,7 @@ var gencommandUpgradeCmd = &cobra.Command{
 			log.Fatalf("failed to parse config file: %s", err)
 		}
 
-		err = generate.GenerateUpgradeCommand(cfg, gencommandOutDir, gencommandNode, gencommandExtraFlags)
+		err = generate.GenerateUpgradeCommand(cfg, gencommandOutDir, gencommandNode, gencommandExtraFlags, gencommandContext)
 		if err != nil {
 			log.Fatalf("failed to generate talosctl upgrade command: %s", err)
 		}

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -225,6 +225,7 @@ talhelper gencommand apply [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
@@ -254,6 +255,7 @@ talhelper gencommand bootstrap [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
@@ -283,6 +285,7 @@ talhelper gencommand health [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
@@ -312,6 +315,7 @@ talhelper gencommand kubeconfig [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
@@ -341,6 +345,7 @@ talhelper gencommand reset [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
@@ -370,11 +375,29 @@ talhelper gencommand upgrade [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
   -n, --node string           A specific node to generate the command for. If not specified, will generate for all nodes.
   -o, --out-dir string        Directory that contains the generated config files to apply. (default "./clusterconfig")
+```
+
+### Example
+
+Generate upgrade commands using the clusterName as talosctl context:
+```
+talhelper gencommand upgrade --context --extra-flags --preserve=true
+```
+
+If your `talconfig.yaml` has `clusterName: k8s-lab`, this will generate commands like:
+```
+talosctl --context=k8s-lab upgrade --nodes=10.10.40.90 --image=factory.talos.dev/... --preserve=true;
+```
+
+Without the `--context` flag, it will use the default `--talosconfig` flag:
+```
+talosctl upgrade --talosconfig=./clusterconfig/talosconfig --nodes=10.10.40.90 --image=factory.talos.dev/... --preserve=true;
 ```
 
 ### SEE ALSO
@@ -399,11 +422,29 @@ talhelper gencommand upgrade-k8s [flags]
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -d, --debug                 Whether to enable debugging mode
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
   -n, --node string           A specific node to generate the command for. If not specified, will generate for all nodes.
   -o, --out-dir string        Directory that contains the generated config files to apply. (default "./clusterconfig")
+```
+
+### Example
+
+Generate upgrade-k8s commands using the clusterName as talosctl context:
+```
+talhelper gencommand upgrade-k8s --context
+```
+
+If your `talconfig.yaml` has `clusterName: k8s-lab`, this will generate commands like:
+```
+talosctl --context=k8s-lab upgrade-k8s --to=v1.32.1 --nodes=10.10.40.90;
+```
+
+Without the `--context` flag, it will use the default `--talosconfig` flag:
+```
+talosctl upgrade-k8s --talosconfig=./clusterconfig/talosconfig --to=v1.32.1 --nodes=10.10.40.90;
 ```
 
 ### SEE ALSO
@@ -418,6 +459,7 @@ Generate commands for talosctl.
 
 ```
   -c, --config-file string    File containing configurations for talhelper (default "talconfig.yaml")
+      --context               Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag.
   -e, --env-file strings      List of files containing env variables for config file (default [talenv.yaml,talenv.sops.yaml,talenv.yml,talenv.sops.yml])
       --extra-flags strings   List of additional flags that will be injected into the generated commands.
   -h, --help                  help for gencommand


### PR DESCRIPTION
## Description

This PR adds a `--context` flag to `gencommand upgrade` and `gencommand upgrade-k8s` commands that automatically uses the `clusterName` from `talconfig.yaml` as the talosctl context instead of the `--talosconfig` flag.

## Motivation

When managing multiple Talos clusters with pre-configured talosctl contexts, users often prefer to use the context name directly rather than specifying the talosconfig file path. This enhancement streamlines the workflow by automatically using the `clusterName` field from the configuration as the context name.

### Use Case

Users who have their talosctl contexts already configured (e.g., via `talosctl config merge`) can now generate commands that use those contexts directly:

**Before:**
```bash
talhelper gencommand upgrade
# Output: talosctl upgrade --talosconfig=./clusterconfig/talosconfig --nodes=10.10.40.90 --image=...
```

**After:**
```bash
talhelper gencommand upgrade --context
# Output: talosctl upgrade --context=k8s-lab --nodes=10.10.40.90 --image=...
```

## Changes

### Core Changes

1. **cmd/gencommand.go**
   - Added `gencommandContext` boolean flag
   - Flag description: "Use clusterName from talconfig.yaml as talosctl context instead of --talosconfig flag."

2. **cmd/gencommand_upgrade.go**
   - Updated to pass the `gencommandContext` flag to `GenerateUpgradeCommand`

3. **cmd/gencommand_upgrade-k8s.go**
   - Updated to pass the `gencommandContext` flag to `GenerateUpgradeK8sCommand`

4. **pkg/generate/command.go**
   - Modified `GenerateUpgradeCommand()` to accept `useContext bool` parameter
   - Modified `GenerateUpgradeK8sCommand()` to accept `useContext bool` parameter
   - When `useContext` is true, both functions now use `cfg.ClusterName` for the `--context` flag instead of `--talosconfig`

### Documentation Changes

5. **docs/docs/reference/cli.md**
   - Updated all gencommand documentation to reflect the new `--context` flag
   - Added usage examples for both `upgrade` and `upgrade-k8s` commands

## Testing

Tested with the following configuration:

```yaml
clusterName: k8s-lab
talosVersion: v1.11.5
kubernetesVersion: v1.34.1
endpoint: https://10.10.40.90:6443
nodes:
  - hostname: k8s-lab-cp
    ipAddress: 10.10.40.90
    controlPlane: true
    installDisk: /dev/sda
```

### Test Results

✅ **With `--context` flag:**
```bash
$ talhelper gencommand upgrade --context
talosctl upgrade --context=k8s-lab --nodes=10.10.40.90 --image=factory.talos.dev/metal-installer/...:v1.11.5;

$ talhelper gencommand upgrade-k8s --context
talosctl upgrade-k8s --context=k8s-lab --to=v1.34.1 --nodes=10.10.40.90;
```

✅ **Without `--context` flag (backward compatibility):**
```bash
$ talhelper gencommand upgrade
talosctl upgrade --talosconfig=./clusterconfig/talosconfig --nodes=10.10.40.90 --image=factory.talos.dev/metal-installer/...:v1.11.5;

$ talhelper gencommand upgrade-k8s
talosctl upgrade-k8s --talosconfig=./clusterconfig/talosconfig --to=v1.34.1 --nodes=10.10.40.90;
```

## Backward Compatibility

This change is **fully backward compatible**. The default behavior (without the `--context` flag) remains unchanged and continues to use `--talosconfig`.

## Additional Notes

- The flag is available as a persistent flag across all `gencommand` subcommands
- The implementation reads `clusterName` directly from the parsed `TalhelperConfig` struct
- No changes to existing configuration files are required
