### PR TITLE
feat(genurl): allow providing customization-file flag

### DIFF
--- a/cmd/genurl.go
+++ b/cmd/genurl.go
@@ -17,6 +17,7 @@ var (
 	genurlOfflineMode bool
 	genurlSecureboot  bool
 	genurlTalosMode   string
+	genurlCustFile    string
 )
 
 var genurlCmd = &cobra.Command{
@@ -37,6 +38,7 @@ func init() {
 	genurlCmd.PersistentFlags().BoolVar(&genurlOfflineMode, "offline-mode", false, "Generate schematic ID without doing POST request to image-factory")
 	genurlCmd.PersistentFlags().BoolVar(&genurlSecureboot, "secure-boot", false, "Whether to generate Secure Boot enabled URL")
 	genurlCmd.PersistentFlags().StringVarP(&genurlTalosMode, "talos-mode", "m", "metal", "Talos runtime mode to generate URL")
+	genurlCmd.PersistentFlags().StringVar(&genurlCustFile, "customization-file", "", "File containing customization spec, this will ignore talconfig.yaml file")
 
 	_ = helpers.MakeNodeCompletion(genurlCmd)
 }


### PR DESCRIPTION
Added `--customization-file` flag for `genurl` command.

This will ignore `--config-file`, `--extension`, and `--kernel-arg` flags and return the installer or image URL from the `customization` file provided.

Example:

We have a file like this:

```yaml
# ./customization.yaml
customization:
  extraKernelArgs:
    - vga=791
  meta:
    - key: 0xa
      value: "{}"
  systemExtensions:
    officialExtensions:
      - siderolabs/gvisor
      - siderolabs/amd-ucode
  bootloader: sd-boot
```

We run: `talhelper genurl installer --customization-file ./customization.yaml`

We get: `factory.talos.dev/metal-installer/941ecd8f2718fe3e32b5706358532c79c672ea1344c8b859b6a1d142955f8f39:v1.11.5`
