### PR TITLE
chore(schema): fixed bootloader type in talconfig.json

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -1,5 +1,20 @@
 package config
 
+import "github.com/siderolabs/image-factory/pkg/schematic"
+
+type SchematicWrapper struct {
+	Overlay       schematic.Overlay    `yaml:"overlay" jsonschema:"description=The overlay options for image generation"`
+	Customization CustomizationWrapper `yaml:"customization" jsonschema:"description=Talos image customization"`
+}
+
+type CustomizationWrapper struct {
+	ExtraKernelArgs  []string                          `yaml:"extraKernelArgs" jsonschema:"description=Extra kernel arguments to be passed to the kernel"`
+	Meta             schematic.MetaValue               `yaml:"meta" jsonschema:"desciption=Initial META contents for the image"`
+	SystemExtensions schematic.SystemExtensions        `yaml:"systemExtensions" jsonschema:"description=Talos system extensions to be installed"`
+	Bootloader       string                            `yaml:"bootloader" jsonschema:"description=The bootloader to be used in the image,enum=sd-boot,enum=grub,enum=dual-boot"`
+	SecureBoot       schematic.SecureBootCustomization `yaml:"secureboot" jsonschema:"description=The secure boot options for the image"`
+}
+
 type InstallDiskSelectorWrapper struct {
 	Size     string `yaml:"size" jsonschema:"description=Disk size,example=4GB"`
 	Name     string `yaml:"name" jsonschema:"Disk name"`
@@ -51,6 +66,13 @@ type FilesystemSpecWrapper struct {
 func (Node) JSONSchemaProperty(prop string) any {
 	if prop == "installDiskSelector" {
 		return &InstallDiskSelectorWrapper{}
+	}
+	return nil
+}
+
+func (NodeConfigs) JSONSchemaProperty(prop string) any {
+	if prop == "schematic" {
+		return &SchematicWrapper{}
 	}
 	return nil
 }

--- a/pkg/config/schemas/talconfig.json
+++ b/pkg/config/schemas/talconfig.json
@@ -214,15 +214,43 @@
           "$ref": "#/$defs/SystemExtensions"
         },
         "bootloader": {
-          "type": "string",
-          "enum": [
-            "dual-boot",
-            "grub",
-            "sd-boot"
-          ]
+          "type": "integer"
         },
         "secureboot": {
           "$ref": "#/$defs/SecureBootCustomization"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CustomizationWrapper": {
+      "properties": {
+        "extraKernelArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Extra kernel arguments to be passed to the kernel"
+        },
+        "meta": {
+          "$ref": "#/$defs/MetaValue"
+        },
+        "systemExtensions": {
+          "$ref": "#/$defs/SystemExtensions",
+          "description": "Talos system extensions to be installed"
+        },
+        "bootloader": {
+          "type": "string",
+          "enum": [
+            "sd-boot",
+            "grub",
+            "dual-boot"
+          ],
+          "description": "The bootloader to be used in the image"
+        },
+        "secureboot": {
+          "$ref": "#/$defs/SecureBootCustomization",
+          "description": "The secure boot options for the image"
         }
       },
       "additionalProperties": false,
@@ -931,7 +959,7 @@
           "description": "Whether to skip schematic validation"
         },
         "schematic": {
-          "$ref": "#/$defs/Schematic",
+          "$ref": "#/$defs/SchematicWrapper",
           "description": "Talos image customization to be used in the installer image"
         },
         "imageSchematic": {
@@ -1072,7 +1100,7 @@
           "description": "Whether to skip schematic validation"
         },
         "schematic": {
-          "$ref": "#/$defs/Schematic",
+          "$ref": "#/$defs/SchematicWrapper",
           "description": "Talos image customization to be used in the installer image"
         },
         "imageSchematic": {
@@ -1212,6 +1240,20 @@
         },
         "customization": {
           "$ref": "#/$defs/Customization"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SchematicWrapper": {
+      "properties": {
+        "overlay": {
+          "$ref": "#/$defs/Overlay",
+          "description": "The overlay options for image generation"
+        },
+        "customization": {
+          "$ref": "#/$defs/CustomizationWrapper",
+          "description": "Talos image customization"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
talconfig.json had schematic.customization.bootloader as type integer which does not match what you get from https://factory.talos.dev/. 

It returns the following:

| Bootloader selection | Bootloader value |
| --- | --- |
| auto | null* |
| sd-boot | sd-boot |
| grub | grub |
| dual-boot | dual-boot |

* When auto is selected the bootloader parameter is left out completely

I have updated it to a string with an enum of the 3 options.
