### PR TITLE
fix: use text/template instead of html/template to prevent HTML encoding

### DIFF
--- a/pkg/templating/template.go
+++ b/pkg/templating/template.go
@@ -2,8 +2,8 @@ package templating
 
 import (
 	"fmt"
-	"html/template"
 	"strings"
+	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 )


### PR DESCRIPTION
This should fix [Issue/1407](https://github.com/budimanjojo/talhelper/issues/1407) _`extraArgs` values with `<` are HTML-encoded as `&lt;` in generated config_

