### PR TITLE
docs: add TOPF alternative

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,6 +45,7 @@ There are some alternatives you can consider instead of `talhelper`.
 
 - The official [Terraform provider](https://registry.terraform.io/providers/siderolabs/talos/latest)
 - The official [Pulumi provider](https://www.pulumi.com/registry/packages/talos/)
+- [TOPF](https://github.com/postfinance/topf) — manages Talos cluster lifecycle with layered patches and SOPS support
 
 ## Bug report and feature request
 


### PR DESCRIPTION
TOPF is a new tool to manage talos-based k8s clusters. 

https://github.com/postfinance/topf/

`talhelper` is already listed as an alternative of TOPF for info :)