### PR TITLE
feat(decrypt): support SOPS decryption for all injected file references

### DIFF
--- a/pkg/decrypt/decrypt.go
+++ b/pkg/decrypt/decrypt.go
@@ -1,10 +1,13 @@
 package decrypt
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 
+	sops "github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
 	"sigs.k8s.io/yaml"
 )
@@ -51,4 +54,23 @@ func DecryptYamlWithSops(filePath string) ([]byte, error) {
 // isEncrypted returns true if `sops` key exists.
 func (s *sopsFile) isEncrypted() bool {
 	return len(s.Sops) != 0
+}
+
+func DecryptFileWithSops(filePath string) ([]byte, error) {
+	slog.Debug(fmt.Sprintf("attempting SOPS decryption of %s", filePath))
+
+	decrypted, err := decrypt.File(filePath, "")
+	if err == nil {
+		return decrypted, nil
+	}
+
+	if errors.Is(err, sops.MetadataNotFound) {
+		return os.ReadFile(filePath)
+	}
+
+	if formats.FormatForPath(filePath) == formats.Binary {
+		return os.ReadFile(filePath)
+	}
+
+	return nil, fmt.Errorf("SOPS decryption failed for %s: %w", filePath, err)
 }

--- a/pkg/decrypt/decrypt_file_test.go
+++ b/pkg/decrypt/decrypt_file_test.go
@@ -1,0 +1,126 @@
+package decrypt
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDecryptFileWithSops_EncryptedYaml(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+
+	result, err := DecryptFileWithSops("testdata/encrypted.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	expected := "hello: world\nsecret: mysecretvalue"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestDecryptFileWithSops_EncryptedJson(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+
+	result, err := DecryptFileWithSops("testdata/encrypted.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(result)
+	if !strings.Contains(got, `"hello": "world"`) {
+		t.Errorf("expected decrypted JSON to contain hello: world, got %q", got)
+	}
+	if !strings.Contains(got, `"secret": "mysecretvalue"`) {
+		t.Errorf("expected decrypted JSON to contain secret: mysecretvalue, got %q", got)
+	}
+}
+
+func TestDecryptFileWithSops_EncryptedDotenv(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+
+	result, err := DecryptFileWithSops("testdata/encrypted.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	if !strings.Contains(got, "HELLO=world") {
+		t.Errorf("expected decrypted dotenv to contain HELLO=world, got %q", got)
+	}
+	if !strings.Contains(got, "SECRET=mysecretvalue") {
+		t.Errorf("expected decrypted dotenv to contain SECRET=mysecretvalue, got %q", got)
+	}
+}
+
+func TestDecryptFileWithSops_UnencryptedYaml(t *testing.T) {
+	result, err := DecryptFileWithSops("testdata/unencrypted.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	expected := "hello: world\nsecret: mysecretvalue"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestDecryptFileWithSops_UnencryptedJson(t *testing.T) {
+	result, err := DecryptFileWithSops("testdata/unencrypted.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	if !strings.Contains(got, `"hello": "world"`) {
+		t.Errorf("expected JSON to contain hello: world, got %q", got)
+	}
+}
+
+func TestDecryptFileWithSops_UnencryptedDotenv(t *testing.T) {
+	result, err := DecryptFileWithSops("testdata/unencrypted.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	if !strings.Contains(got, "HELLO=world") {
+		t.Errorf("expected dotenv to contain HELLO=world, got %q", got)
+	}
+}
+
+func TestDecryptFileWithSops_PlainTextFile(t *testing.T) {
+	result, err := DecryptFileWithSops("testdata/plain.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(string(result))
+	expected := "hello: world\nsecret: mysecretvalue"
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestDecryptFileWithSops_NonExistentFile(t *testing.T) {
+	_, err := DecryptFileWithSops("testdata/does-not-exist.yaml")
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+}
+
+func TestDecryptFileWithSops_EncryptedWithMissingKey(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "")
+
+	_, err := DecryptFileWithSops("testdata/encrypted.yaml")
+	if err == nil {
+		t.Fatal("expected SOPS decryption error when key is missing, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "SOPS decryption failed") {
+		t.Errorf("expected error to contain 'SOPS decryption failed', got %q", err.Error())
+	}
+}

--- a/pkg/decrypt/testdata/encrypted.env
+++ b/pkg/decrypt/testdata/encrypted.env
@@ -1,0 +1,8 @@
+HELLO=ENC[AES256_GCM,data:Pb/s9Bw=,iv:RWkSWQrhsOMxQ47XT5ISgsy98aL3cVSDB6Fvksbxelo=,tag:N0E7y7BvYrjoswzVA0d6VA==,type:str]
+SECRET=ENC[AES256_GCM,data:EAEBSCe7l/l0BLTzCg==,iv:NAg+P1FL4sdxqEHZc/aBZOIQO+jt+pplbs211zQsPmw=,tag:aKTOFhKRxhD/MW1csk3RmA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCR2xIaE1LZDBkZzZqeHVt\nQXZ6WDkwYWdGTXVpK2dGemgwVFFaeXNta1ZNCm5lc0UrWlRFb2xpWnZEa2s1a2Q5\nQ1FobnM2TFEyTkFuQkdqYXVXbnYvYWMKLS0tIE5OR1JBNmRPM3kwM2tCZm52R2NR\nRC85YklIK3o3Z2FLOHpFWlVpREp0SjQKQ/7YxGQM53au4bfMTljaS334kvfNt5Vr\nQXR4dvtJP1IOEKGFH5nN6XpoYG0PLONZf0/dx0SWB3njMTR//GWdog==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age10k9mjx3wcfzd7dwx3uqs68v7dzlwvwpzp8jyjpysjhy9mdwzhghqy2vhvn
+sops_lastmodified=2026-04-09T14:57:12Z
+sops_mac=ENC[AES256_GCM,data:1xPCZX6uI73vbgKUoTKF2eQjAGjkArzYnZIJHrWADrL+wwZG3kOHGjdmg+R9LMALoYc0aQMFl1a8qjYiDpTw800WjrTUDcKjiIpWdumKYd7hL1lY58s291Cd1i4lpkJSkV3osP4NTDdpqHKoqoUhVh5xu05dnU6nxC0w7BXxXDg=,iv:ywZXl+CZOxC7u8ZftvYnH4kd8VSFdiod4/XMqvViUt0=,tag:2w6Mw1wQ9Eeok4D+/VwTkQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.11.0

--- a/pkg/decrypt/testdata/encrypted.json
+++ b/pkg/decrypt/testdata/encrypted.json
@@ -1,0 +1,16 @@
+{
+	"hello": "ENC[AES256_GCM,data:7gdOjN0=,iv:y2Arq2HYLrNwzaSVRNi1OdqFDqi1YbenxOGV/CcdWlY=,tag:2CmFSZSZFYXAlwX0vClq2Q==,type:str]",
+	"secret": "ENC[AES256_GCM,data:PGylwCpqoufiNvWaZw==,iv:/r/LlpwDmWkx+/+IVjrQEEsJznxwnamb2DtN2Lf+4c4=,tag:uRLdif+co1VKlZS878GkuA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age10k9mjx3wcfzd7dwx3uqs68v7dzlwvwpzp8jyjpysjhy9mdwzhghqy2vhvn",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqM01ZRHdxWlphNXVTVm5h\nOGZBVUNXVmk0RHg3a0ZTOENNSEJxamJ5c3gwCjlJSmlUN1NCbmc3Nk8vdXNrYzBC\naVB6UGdpemtzTVhpU2dBTmQwOFAzWDgKLS0tIGN1Z2ZBMVhnUUpYUlZMcFZ6ZTlX\nUGZ0SjFRY2RaekV6YmZiV1I0enZxTW8K2o8Y/7uo5H1H+ow7T8LhIefQjt0qhsST\ns6oAzTme6k9GYekBpb5pAsIT0+d+ptmUvLo+PrkuSgYFXgFxw+kIMg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-04-09T14:57:12Z",
+		"mac": "ENC[AES256_GCM,data:bogT/oEGJ7aoqkAECUS8vkV+oNKt+Bv6RMvQ+wlYkVP+5k+6kDyZJa2L97dmtMRwVmO/AKMhzLq8v3vix8zq7y3C9RwI7W/jmjG/CY6tgESHzI4ST24KwgHoDCT6pkREQTnULaUXCAsNsCQkgKOXhBfCIvexiB9w63y1Lp38wOA=,iv:3tJzNTOjXdDsyOClem9ea8pp2TemIxnJBpLbjhbUmbM=,tag:E+6LWtXpOCbhbiiA1oTBDA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}

--- a/pkg/decrypt/testdata/encrypted.yaml
+++ b/pkg/decrypt/testdata/encrypted.yaml
@@ -1,0 +1,17 @@
+hello: ENC[AES256_GCM,data:iLUHUNk=,iv:0S/iHxIP9jeq5a3skzk0Xux6F3bQoYqaNafdHumr1bc=,tag:F6YSyjJ+NWeg94mtt4AkMg==,type:str]
+secret: ENC[AES256_GCM,data:DO1eLZrs3z25MbOLSg==,iv:w7Ns7yXAv60Hig7XeU1G6Z7ypM1oKk7CbhsQ1OwOpJQ=,tag:ziWUgu2xLy3sj6kKTzjMlw==,type:str]
+sops:
+    age:
+        - recipient: age10k9mjx3wcfzd7dwx3uqs68v7dzlwvwpzp8jyjpysjhy9mdwzhghqy2vhvn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpUUNxQ1VvV214ZEF0K2V1
+            eVZka1RIV2d0bytIcFE3Nk9hTDl2Q3NscERRCldTTisxR2g3bFF4ZjJ4NjVhU0Zi
+            dTZVWmJaYlRkQmpBRldVbEtobEtJS00KLS0tIEx3WVkyb1I2TXhIcC9uNTB0UUJZ
+            S21aRTZqTzY0clBuNXBRU0ZlYzhwSG8KgbvPh0ey8l0sbiAlNM5IIZS9fDZwsQgi
+            PitfhGF7VEj2tY07zmSjQYhKX4T4vKhW8DspFJimTcqVrwvGjWmZkA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-09T14:57:12Z"
+    mac: ENC[AES256_GCM,data:XR0Ivzul+KuVJeuHVrnBcJ4kp1BF3hJC8tsvqjAPjlZI1QJjMrf4ny5OjmD/1a5e6wajy6EVZVR3Zr1THIzGxyhBnGoOb9r/u9BM5aUOcQ8CcpHna4GdSnF94nDmZe/KV4Y5v7gJ1nMbWwO8CsLXGkzpAsWKXaNDuZTjMu6wREo=,iv:ufsLb5YSZwsZhOV3CY1mvgoNPKQAg61VYHBl0ZGgWy0=,tag:otFjOrDNaSsSpMajXtAvOA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/pkg/decrypt/testdata/plain.txt
+++ b/pkg/decrypt/testdata/plain.txt
@@ -1,0 +1,2 @@
+hello: world
+secret: mysecretvalue

--- a/pkg/decrypt/testdata/unencrypted.env
+++ b/pkg/decrypt/testdata/unencrypted.env
@@ -1,0 +1,2 @@
+HELLO=world
+SECRET=mysecretvalue

--- a/pkg/decrypt/testdata/unencrypted.json
+++ b/pkg/decrypt/testdata/unencrypted.json
@@ -1,0 +1,1 @@
+{"hello": "world", "secret": "mysecretvalue"}

--- a/pkg/decrypt/testdata/unencrypted.yaml
+++ b/pkg/decrypt/testdata/unencrypted.yaml
@@ -1,0 +1,2 @@
+hello: world
+secret: mysecretvalue

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/budimanjojo/talhelper/v3/pkg/config"
+	"github.com/budimanjojo/talhelper/v3/pkg/decrypt"
 	"github.com/budimanjojo/talhelper/v3/pkg/patcher"
 	"github.com/budimanjojo/talhelper/v3/pkg/talos"
 	"github.com/budimanjojo/talhelper/v3/pkg/templating"
@@ -154,11 +155,7 @@ func getFileContent(path string) (string, error) {
 // if any
 func getFileContentByte(path string) ([]byte, error) {
 	if _, osErr := os.Stat(path); osErr == nil {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-		return content, nil
+		return decrypt.DecryptFileWithSops(path)
 	} else if errors.Is(osErr, os.ErrNotExist) {
 		return nil, nil
 	} else {

--- a/pkg/generate/config_test.go
+++ b/pkg/generate/config_test.go
@@ -1,0 +1,56 @@
+package generate
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetFileContentByte_SopsEncryptedFile(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+
+	result, err := getFileContentByte("testdata/encrypted-manifest.sops.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(result)
+	if !strings.Contains(got, "password: p4ssw0rd") {
+		t.Errorf("expected decrypted content to contain 'password: p4ssw0rd', got %q", got)
+	}
+	if !strings.Contains(got, "name: db-credentials") {
+		t.Errorf("expected decrypted content to contain 'name: db-credentials', got %q", got)
+	}
+}
+
+func TestGetFileContentByte_UnencryptedFile(t *testing.T) {
+	result, err := getFileContentByte("testdata/unencrypted-manifest.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(result)
+	if !strings.Contains(got, "name: production") {
+		t.Errorf("expected content to contain 'name: production', got %q", got)
+	}
+}
+
+func TestGetFileContentByte_NonExistentFile(t *testing.T) {
+	result, err := getFileContentByte("testdata/does-not-exist.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != nil {
+		t.Errorf("expected nil for non-existent file, got %q", string(result))
+	}
+}
+
+func TestGetFileContentByte_SopsEncryptedWithMissingKey(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "")
+
+	_, err := getFileContentByte("testdata/encrypted-manifest.sops.yaml")
+	if err == nil {
+		t.Fatal("expected SOPS decryption error when key is missing, got nil")
+	}
+}

--- a/pkg/generate/testdata/encrypted-manifest.sops.yaml
+++ b/pkg/generate/testdata/encrypted-manifest.sops.yaml
@@ -1,0 +1,21 @@
+apiVersion: ENC[AES256_GCM,data:xcw=,iv:V8o9g0ZaBr1G2gTWJNbrbKa13xQUuaDeU4zQdiRM3Fo=,tag:EHmPQkt5TGlRvFK+ZRGiAQ==,type:str]
+kind: ENC[AES256_GCM,data:Z5aZacOg,iv:IvEpg82r3CZm6gnhqemGQfhC79MLzYUEBDRWKtBEk0k=,tag:8DKycSDL6+p1g4l0ebSDXg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:joliEk7xHVAC534iUY8=,iv:9TlTXHC3Uw95gXOc082rL/LNjmMGIamXBft+fKnzmPo=,tag:ddmUnDkfpNXlvV6eH/VcWw==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:xhcCFGg70JI=,iv:7IFRNV8Nc+KEg+5NINrcq+YA6A5kD3IgH3d/uIqSqfI=,tag:k6wl5E/L5vvAtaDqFkZamQ==,type:str]
+sops:
+    age:
+        - recipient: age10k9mjx3wcfzd7dwx3uqs68v7dzlwvwpzp8jyjpysjhy9mdwzhghqy2vhvn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhQWUrT0FSK0psUkRiWnhR
+            TTJGYzdhbW5KV016K0t6RHA1aGg1STM0d0NjCjllTVo5VFNic3p0YkdFYngyNU90
+            NFpjekxGZzBoaEdFV2JvL2RNSGEzajgKLS0tIEh2djNoZHlTRFN3OURDSTdJdU1r
+            d1VGOVVFQTJoZkdnV3F3SUlJVmN0ekUKCTTIT1vJZtnmukW0vDw88LlTMXZIFl6K
+            S90yvZaZXmRtYA+Q+u25j2bxzq1dD9ilr52pK+4NjyWyNxPMoRTnWA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-09T15:00:04Z"
+    mac: ENC[AES256_GCM,data:rJfQqmgIZqUT5bxiHZlQLzHFaVaVbPAk9dDkuzeDbtdz5uhgm29nJLnVETPq8vMM9EbsxQjsTOC9dlZO7NNV5yEvlhIfwQOhhDwtzes9ivEt/zZpqIZMtyQ83DFNjGxZgLyawXGhAz+fIlrkXemTXu85wRB9mAP1HXfr8OaktCg=,iv:j3pPWXi2taEAUNXcbotJQFCEcR965rIgWFBgfl4ZNbI=,tag:I+XVG2WMImuV3zRXic6UDg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/pkg/generate/testdata/unencrypted-manifest.yaml
+++ b/pkg/generate/testdata/unencrypted-manifest.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production

--- a/pkg/substitute/contentsubst.go
+++ b/pkg/substitute/contentsubst.go
@@ -3,8 +3,9 @@ package substitute
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
+
+	"github.com/budimanjojo/talhelper/v3/pkg/decrypt"
 )
 
 // SubstituteFileContent will read and return the content of a file if `value` is string prefixed with `@`
@@ -16,7 +17,7 @@ func SubstituteFileContent(value string, envsubst bool) (string, error) {
 		slog.Debug(fmt.Sprintf("getting file content of %s", value))
 		filename := value[1:]
 
-		contents, err := os.ReadFile(filename)
+		contents, err := decrypt.DecryptFileWithSops(filename)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/substitute/contentsubst_test.go
+++ b/pkg/substitute/contentsubst_test.go
@@ -6,6 +6,67 @@ import (
 	"testing"
 )
 
+func TestSubstituteFileContent_SopsEncryptedFile(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+
+	result, err := SubstituteFileContent("@./testdata/encrypted-manifest.sops.yaml", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "password: supersecret") {
+		t.Errorf("expected decrypted content to contain 'password: supersecret', got %q", result)
+	}
+	if !strings.Contains(result, "name: my-secret") {
+		t.Errorf("expected decrypted content to contain 'name: my-secret', got %q", result)
+	}
+}
+
+func TestSubstituteFileContent_SopsEncryptedWithMissingKey(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "")
+
+	_, err := SubstituteFileContent("@./testdata/encrypted-manifest.sops.yaml", false)
+	if err == nil {
+		t.Fatal("expected SOPS decryption error when key is missing, got nil")
+	}
+}
+
+func TestSubstituteFileContent_SopsEncryptedWithEnvsubst(t *testing.T) {
+	os.Setenv("SOPS_AGE_KEY", "AGE-SECRET-KEY-172FENV3SDP8JSRRX2SWTA9JQMAW7MW3GSKJ2JZDNXS4GVFAS5STQUW8WN4")
+	os.Setenv("EXPECTED_NAME", "my-secret")
+
+	result, err := SubstituteFileContent("@./testdata/encrypted-manifest.sops.yaml", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "password: supersecret") {
+		t.Errorf("expected decrypted content to contain 'password: supersecret', got %q", result)
+	}
+}
+
+func TestSubstituteFileContent_NonSopsFile(t *testing.T) {
+	result, err := SubstituteFileContent("@./testdata/content.yaml", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "hubble-ui-nginx") {
+		t.Errorf("expected content to contain 'hubble-ui-nginx', got %q", result)
+	}
+}
+
+func TestSubstituteFileContent_NoAtPrefix(t *testing.T) {
+	result, err := SubstituteFileContent("literal value", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != "literal value" {
+		t.Errorf("got %q, want %q", result, "literal value")
+	}
+}
+
 func TestSubstituteFileContent(t *testing.T) {
 	contents := []string{
 		"@./testdata/content.yaml",

--- a/pkg/substitute/testdata/encrypted-manifest.sops.yaml
+++ b/pkg/substitute/testdata/encrypted-manifest.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: ENC[AES256_GCM,data:WHM=,iv:H2uL4wPvBBXY+znwDxJ8tlFik1DWT+924IHAqmIF5kc=,tag:14wnqgjNTnt5FxwdVHfGuA==,type:str]
+kind: ENC[AES256_GCM,data:Ai4qVROy,iv:b3T+KA5Ct8kllWFpiRuusjW6wM8l2wZ9gF2v+4XUmA8=,tag:yoYEotKeY/reWj15isgZMg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:JXt85ZG1/OIa,iv:O2EWv45KIBnAt0x//GH4wXE65Joac4t2knXSQSDGrJ0=,tag:CUTjFczTn+gQSdxNaKrkLw==,type:str]
+    namespace: ENC[AES256_GCM,data:WSLonZw7eA==,iv:JRZJIe9eElgNbUe9ofTH/3SC/5gfOs4WrxzaQY0udPU=,tag:bDAVqwZPyWgLf1S1Xd0GeA==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:yN9DeBPxVnzgNvo=,iv:v1epqH7NY4zl2XnxOjNVTPw4Agqvf2BLvM/hIiUIhUg=,tag:F/ImefEBiGWVId+vgABOnQ==,type:str]
+sops:
+    age:
+        - recipient: age10k9mjx3wcfzd7dwx3uqs68v7dzlwvwpzp8jyjpysjhy9mdwzhghqy2vhvn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBQlVIcml1cnVQai9LZVlp
+            bEVwRWlUcXhKTVFtRnV1UTl4ODc2cytXSFU0CjRkckF4T0l3djM1dW4rZzNtNXZE
+            alVNczA2bVZkTllhc0s1VCtSWnBva0EKLS0tIEVnd0FrZzVER3M2WnJKRm5JWjlm
+            eDNvY2U3TzJZMS9oSForQ0NnMFhDcFEKpOYRRZo2t4EL9C1sFQBFv349gjWFNSKe
+            BdWgMzrjOnymEezwPaTaSA//8W56d55QgTPfaGo3z0yF+x9OOxRb8A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-09T14:59:09Z"
+    mac: ENC[AES256_GCM,data:n0bxMgayjU1fzVdbuCI/HOdEhXLpjL//X+g1JWIYdlbYHHUc7CwD9e2pDhuad65vt8Z094WZ0Hm7Lf8Lxp1qmiJ2F6x7TwJHlNtPy5ZQR8+oP1rA6rV4rLrVTJwRftXBvqs9++PahTcKkoeX/HBlV+pK9N16hzrUFaR/DUcJmUo=,iv:vUj1wQrNJDcHXQ0wFswNnNntbKYzWNP3W4L+pbdtnKE=,tag:66B7AZPYe+VJserZRx2weQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/pkg/substitute/testdata/encrypted-manifest.yaml
+++ b/pkg/substitute/testdata/encrypted-manifest.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+stringData:
+  password: supersecret


### PR DESCRIPTION
Currently, only patches support SOPS decryption when loaded from external files. This means inlineManifests, machineFiles, and extraManifests inject encrypted content as-is, producing invalid configs and forcing users to manually decrypt files before running talhelper genconfig.

Add a format-agnostic DecryptFileWithSops function that uses the SOPS library's built-in format detection (yaml, json, dotenv, ini, binary) and transparent encryption detection — no naming convention required. Files without SOPS metadata are returned as-is; real decryption errors (missing keys, MAC mismatch) are propagated, not swallowed.

Wire it into SubstituteFileContent (inlineManifests, machineFiles) and getFileContentByte (extraManifests).

Closes #1530