### PR TITLE
fix(talos): skip multidoc patching if no docs generated

### DIFF
--- a/pkg/talos/multidocs.go
+++ b/pkg/talos/multidocs.go
@@ -18,6 +18,9 @@ func AddMultiDocs(node *config.Node, mode string, corecfg []byte, vc *tconfig.Ve
 	if err != nil {
 		return nil, err
 	}
+	if extradocs == nil {
+		return corecfg, nil
+	}
 
 	// TODO: A better way is to append them as documents and use upstream API
 	// But the problem is upstream Generate API is generating not just the core config

--- a/pkg/talos/multidocs_test.go
+++ b/pkg/talos/multidocs_test.go
@@ -12,38 +12,52 @@ import (
 )
 
 func TestAddMultiDocs(t *testing.T) {
-	data := map[string]*tconfig.VersionContract{
-		"node1": {Major: 1, Minor: 11},
-		"node2": {Major: 1, Minor: 11},
-		"node3": {Major: 1, Minor: 12},
+	tests := []struct {
+		name    string
+		file    string
+		version *tconfig.VersionContract
+	}{
+		{"ingress firewall without multidoc", "node1", &tconfig.VersionContract{Major: 1, Minor: 11}},
+		{"user volumes without multidoc", "node2", &tconfig.VersionContract{Major: 1, Minor: 11}},
+		{"ingress firewall with multidoc", "node3", &tconfig.VersionContract{Major: 1, Minor: 12}},
+		{"no multidocs", "node4", &tconfig.VersionContract{Major: 1, Minor: 11}},
 	}
 
-	for node, version := range data {
-		basecfg, err := os.ReadFile("testdata/" + node + "_basecfg.yaml")
-		if err != nil {
-			t.Fatal(err)
-		}
-		in, err := os.ReadFile("testdata/" + node + "_input.yaml")
-		if err != nil {
-			t.Fatal(err)
-		}
-		expected, err := os.ReadFile("testdata/" + node + "_expected.yaml")
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			basecfg, n, expected := loadMultiDocsTestdata(t, tt.file)
 
-		var n config.Node
-		if err := yaml.Unmarshal(in, &n); err != nil {
-			t.Fatal(err)
-		}
+			res, err := AddMultiDocs(&n, "metal", basecfg, tt.version)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		res, err := AddMultiDocs(&n, "metal", basecfg, version)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !bytes.Equal(res, expected) {
-			t.Error(diff.Diff(string(res), string(expected)))
-		}
+			if !bytes.Equal(res, expected) {
+				t.Error(diff.Diff(string(res), string(expected)))
+			}
+		})
 	}
+}
+
+func loadMultiDocsTestdata(t *testing.T, node string) (basecfg []byte, n config.Node, expected []byte) {
+	t.Helper()
+
+	basecfg, err := os.ReadFile("testdata/" + node + "_basecfg.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := os.ReadFile("testdata/" + node + "_input.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err = os.ReadFile("testdata/" + node + "_expected.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := yaml.Unmarshal(in, &n); err != nil {
+		t.Fatal(err)
+	}
+
+	return basecfg, n, expected
 }

--- a/pkg/talos/testdata/node4_basecfg.yaml
+++ b/pkg/talos/testdata/node4_basecfg.yaml
@@ -1,0 +1,9 @@
+---
+version: v1alpha1
+debug: false
+persist: true
+machine:
+  type: controlplane
+cluster:
+  controlPlane:
+    endpoint: https://1.1.1.1:6443

--- a/pkg/talos/testdata/node4_expected.yaml
+++ b/pkg/talos/testdata/node4_expected.yaml
@@ -1,0 +1,9 @@
+---
+version: v1alpha1
+debug: false
+persist: true
+machine:
+  type: controlplane
+cluster:
+  controlPlane:
+    endpoint: https://1.1.1.1:6443

--- a/pkg/talos/testdata/node4_input.yaml
+++ b/pkg/talos/testdata/node4_input.yaml
@@ -1,0 +1,2 @@
+---
+hostname: node4


### PR DESCRIPTION
Due to a change in upstream dependency (Talos machinery -> YAML), running patching on an empty (nil) byte slice produces an error. For the user that results in the following error:

    2026/07/22 11:35:05 failed to generate talos config: config not found

Many simple configurations will result in zero multidocs. Let's skip invoking the patcher completely in this case.

Fixes budimanjojo/talhelper#1698.